### PR TITLE
chore: fix tsconfig.json **exclude** property

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,12 +18,12 @@
       "module": "preserve",
       "noEmit": true,
       "lib": ["es2022"],
-      "exclude": [
+    },
+    "exclude": [
         "**/dist/**",
         "**/node_modules/**",
         "**/test/**",
         "**/playground/src/components/**",
         "**/packages/ui/src/components/**"
       ]
-    }
   }


### PR DESCRIPTION
This PR is intended to fix the tsconfig.json file by moving the exclude property from the compilerOptions object to the root object.