### PR TITLE
fix(docs): Github edit links pointing to non existing files on main

### DIFF
--- a/docs/.vitepress/plugins/code/utils.ts
+++ b/docs/.vitepress/plugins/code/utils.ts
@@ -17,7 +17,7 @@ export function getDemoComponent(
 ) {
   const componentName = `DemoComponent${index++}`
   path = normalizePath(path)
-  const github = `https://github.com/selemondev/spark-ui/tree/main/${path.split('/').slice(-4).join('/')}`
+  const github = `https://github.com/selemondev/spark-ui/blob/dev/docs/${path.split('/').slice(-4).join('/')}`
 
   injectImportStatement(env, componentName, path)
 


### PR DESCRIPTION
**What was wrong?**
The `Edit on Github` link in docs was pointing to non existing files on main. It also assumed you having access to edit the file directly, as it was pointing to /tree/ instead of /blob/

**What was the fix?**
- Edit on Github link now points to the dev branch.
- The link now points to /blob/ instead of /tree/