### PR TITLE
feat(comic-text): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -12,6 +12,7 @@ const newComponents = [
   { text: "Scroll Progress", link: "/content/components/scroll-progress.md" },
   { text: "Aurora Text", link: "/content/components/aurora.md" },
   { text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
+  { text: "Comic Text", link: "/content/components/comic-text.md" },
 ];
 
 const components = [

--- a/docs/content/components/comic-text.md
+++ b/docs/content/components/comic-text.md
@@ -1,0 +1,112 @@
+# Comic Text
+
+Comic text animation that looks like a comic book text.
+
+<demo src="../../src/example/comic-text/demo.vue" srcCode="../../src/spark-ui-demos/comic-text/comic-text.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [comic-text.vue]
+<script setup lang="ts">
+import type { CSSProperties } from "vue";
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+interface ComicTextProps {
+  class?: string;
+  style?: CSSProperties;
+  fontSize?: number;
+}
+
+const props = withDefaults(defineProps<ComicTextProps>(), {
+  fontSize: 5,
+});
+
+const dotColor = "#EF4444";
+const backgroundColor = "#FACC15";
+
+const comicStyle = computed<CSSProperties>(() => ({
+  fontSize: `${props.fontSize}rem`,
+  fontFamily: "'Bangers', 'Comic Sans MS', 'Impact', sans-serif",
+  fontWeight: "900",
+  WebkitTextStroke: `${props.fontSize * 0.35}px #000000`,
+  transform: "skewX(-10deg)",
+  textTransform: "uppercase",
+  filter: `
+    drop-shadow(5px 5px 0px #000000)
+    drop-shadow(3px 3px 0px ${dotColor})
+  `,
+  backgroundColor,
+  backgroundImage: `radial-gradient(circle at 1px 1px, ${dotColor} 1px, transparent 0)`,
+  backgroundSize: "8px 8px",
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  ...props.style,
+}));
+</script>
+
+<template>
+  <div :class="cn('animate-comic-text text-center select-none', props.class)" :style="comicStyle">
+    <slot />
+  </div>
+</template>
+```
+
+:::
+
+Add the following animation to your `tailwind.config.js` file:
+
+```js {5,6,7,8,9,10,11,12,13,14,15,16,17} [tailwind.config.js]
+module.exports = {
+  theme: {
+    extend: {
+      keyframes: {
+        "comic-text": {
+          from: {
+            opacity: "0",
+            transform: "skewX(-10deg) scale(0.8) rotate(-2deg)",
+          },
+          to: {
+            opacity: "1",
+            transform: "skewX(-10deg) scale(1) rotate(0deg)",
+          },
+        },
+      },
+      animation: {
+        "comic-text": "comic-text 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) both",
+      },
+    },
+  },
+};
+```
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import ComicText from "@/components/ui/comic-text.vue";
+</script>
+
+<template>
+  <ComicText :font-size="5">BOOM!</ComicText>
+</template>
+```
+
+## Props
+
+| Prop       | Type            | Default | Description                                    |
+| ---------- | --------------- | ------- | ---------------------------------------------- |
+| `class`    | `string`        | `-`     | The class name to be applied to the component. |
+| `fontSize` | `number`        | `5`     | The font size of the text (in rem).            |
+| `style`    | `CSSProperties` | `-`     | Additional inline styles for the text.         |
+
+## Slots
+
+| Slot      | Description               |
+| --------- | ------------------------- |
+| `default` | The text to be displayed. |

--- a/docs/src/components/spark-ui/comic-text/comic-text.vue
+++ b/docs/src/components/spark-ui/comic-text/comic-text.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { CSSProperties } from "vue";
+import { computed } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface ComicTextProps {
+  class?: string;
+  style?: CSSProperties;
+  fontSize?: number;
+}
+
+const props = withDefaults(defineProps<ComicTextProps>(), {
+  fontSize: 5,
+});
+
+const dotColor = "#EF4444";
+const backgroundColor = "#FACC15";
+
+const comicStyle = computed<CSSProperties>(() => ({
+  fontSize: `${props.fontSize}rem`,
+  fontFamily: "'Bangers', 'Comic Sans MS', 'Impact', sans-serif",
+  fontWeight: "900",
+  WebkitTextStroke: `${props.fontSize * 0.35}px #000000`,
+  transform: "skewX(-10deg)",
+  textTransform: "uppercase",
+  filter: `
+    drop-shadow(5px 5px 0px #000000)
+    drop-shadow(3px 3px 0px ${dotColor})
+  `,
+  backgroundColor,
+  backgroundImage: `radial-gradient(circle at 1px 1px, ${dotColor} 1px, transparent 0)`,
+  backgroundSize: "8px 8px",
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  ...props.style,
+}));
+</script>
+
+<template>
+  <div :class="cn('animate-comic-text text-center select-none', props.class)" :style="comicStyle">
+    <slot />
+  </div>
+</template>

--- a/docs/src/example/comic-text/comic-text.vue
+++ b/docs/src/example/comic-text/comic-text.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { CSSProperties } from "vue";
+import { computed } from "vue";
+import { cn } from "../../lib/utils";
+
+interface ComicTextProps {
+  class?: string;
+  style?: CSSProperties;
+  fontSize?: number;
+}
+
+const props = withDefaults(defineProps<ComicTextProps>(), {
+  fontSize: 5,
+});
+
+const dotColor = "#EF4444";
+const backgroundColor = "#FACC15";
+
+const comicStyle = computed<CSSProperties>(() => ({
+  fontSize: `${props.fontSize}rem`,
+  fontFamily: "'Bangers', 'Comic Sans MS', 'Impact', sans-serif",
+  fontWeight: "900",
+  WebkitTextStroke: `${props.fontSize * 0.35}px #000000`,
+  transform: "skewX(-10deg)",
+  textTransform: "uppercase",
+  filter: `
+    drop-shadow(5px 5px 0px #000000)
+    drop-shadow(3px 3px 0px ${dotColor})
+  `,
+  backgroundColor,
+  backgroundImage: `radial-gradient(circle at 1px 1px, ${dotColor} 1px, transparent 0)`,
+  backgroundSize: "8px 8px",
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  ...props.style,
+}));
+</script>
+
+<template>
+  <div :class="cn('animate-comic-text text-center select-none', props.class)" :style="comicStyle">
+    <slot />
+  </div>
+</template>

--- a/docs/src/example/comic-text/demo.vue
+++ b/docs/src/example/comic-text/demo.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import ComicText from "./comic-text.vue";
+</script>
+
+<template>
+  <div class="space-y-8 text-center">
+    <ComicText :font-size="5">BOOM!</ComicText>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/comic-text/comic-text.vue
+++ b/docs/src/spark-ui-demos/comic-text/comic-text.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import ComicText from "../../components/spark-ui/comic-text/comic-text.vue";
+</script>
+
+<template>
+  <div class="space-y-8 text-center">
+    <ComicText :font-size="5">BOOM!</ComicText>
+  </div>
+</template>

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -171,6 +171,16 @@ module.exports = withAnimations({
           },
         },
 
+        "comic-text": {
+          from: {
+            opacity: "0",
+            transform: "skewX(-10deg) scale(0.8) rotate(-2deg)",
+          },
+          to: {
+            opacity: "1",
+            transform: "skewX(-10deg) scale(1) rotate(0deg)",
+          },
+        },
         "shine-pulse": {
           "0%": {
             "background-position": "0% 0%",
@@ -198,6 +208,7 @@ module.exports = withAnimations({
         marquee: "marquee var(--duration) linear infinite",
         "marquee-vertical": "marquee-vertical var(--duration) linear infinite",
         shimmer: "shimmer 8s infinite",
+        "comic-text": "comic-text 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275) both",
       },
     },
   },

--- a/tests/comic-text/comic-text.spec.ts
+++ b/tests/comic-text/comic-text.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import ComicText from "../../docs/src/components/spark-ui/comic-text/comic-text.vue";
+
+it("renders slot content", () => {
+  const wrapper = mount(ComicText, { slots: { default: "BOOM!" } });
+  expect(wrapper.text()).toBe("BOOM!");
+});
+
+it("applies base comic styling and animation class", () => {
+  const wrapper = mount(ComicText, { slots: { default: "POW" } });
+  const el = wrapper.get("div");
+  expect(el.classes()).toContain("animate-comic-text");
+  expect(el.classes()).toContain("text-center");
+  expect(el.classes()).toContain("select-none");
+  const style = el.attributes("style") ?? "";
+  expect(style).toContain("skewX(-10deg)");
+  expect(style).toContain("text-transform: uppercase");
+});
+
+it("defaults fontSize to 5rem with proportional text stroke", () => {
+  const wrapper = mount(ComicText, { slots: { default: "BAM" } });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("font-size: 5rem");
+  expect(style).toContain("1.75px #000000");
+});
+
+it("respects a custom fontSize", () => {
+  const wrapper = mount(ComicText, {
+    props: { fontSize: 10 },
+    slots: { default: "ZAP" },
+  });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("font-size: 10rem");
+  expect(style).toContain("3.5px #000000");
+});
+
+it("merges a custom class", () => {
+  const wrapper = mount(ComicText, {
+    props: { class: "my-custom" },
+    slots: { default: "WOW" },
+  });
+  expect(wrapper.get("div").classes()).toContain("my-custom");
+});
+
+it("merges custom inline styles", () => {
+  const wrapper = mount(ComicText, {
+    props: { style: { color: "rgb(0, 128, 0)" } },
+    slots: { default: "HEY" },
+  });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("color: rgb(0, 128, 0)");
+});


### PR DESCRIPTION
Ports Magic UI's **Comic Text** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/comic-text/comic-text.vue` — comic-style text with proportional text stroke, layered drop-shadows, radial-gradient dot pattern and `background-clip: text`, all preserved via computed styles; upstream `children` becomes the default slot
- Entry animation translated from framer-motion to a CSS keyframe that bakes the base `skewX(-10deg)` into every frame (framer composes transforms per-property; a naive `v-motion` port would clobber the skew) with the exact upstream cubic-bezier and duration — SSR-safe, no JS
- Live demo, copy-paste source, docs page (installation incl. tailwind keyframe, usage, props/slots), sidebar entry
- 6 passing tests in `tests/comic-text/`

## Verification
- `pnpm lint` ✅
- `vue-tsc` docs typecheck ✅ (`scripts/tsconfig.json` step fails on `dev` too — pre-existing)
- `pnpm dlx tsx scripts/validate-component.ts` ✅
- Tests ✅ (6 passed)