### PR TITLE
feat(dia-text-reveal): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,6 +19,7 @@ const newComponents = [
 	{ text: "Aurora Text", link: "/content/components/aurora.md" },
 	{ text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
+	{ text: "Dia Text Reveal", link: "/content/components/dia-text-reveal.md" },
 ];
 
 const components = [

--- a/docs/content/components/dia-text-reveal.md
+++ b/docs/content/components/dia-text-reveal.md
@@ -1,0 +1,319 @@
+# Dia Text Reveal
+
+A horizontal color band sweeps across text with a gradient shine, then settles on your theme foreground color.
+
+<demo src="../../src/example/dia-text-reveal/demo.vue" srcCode="../../src/spark-ui-demos/dia-text-reveal/dia-text-reveal.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [dia-text-reveal.vue]
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { cn } from "@/lib/utils";
+
+interface DiaTextRevealProps {
+  /** Text to reveal. Pass multiple strings to rotate when `repeat` is `true`. */
+  text: string | string[];
+  /** Colors sampled across the moving gradient band. */
+  colors?: string[];
+  /** CSS color for revealed text after the sweep and for leading/trailing regions. */
+  textColor?: string;
+  /** Duration of one sweep pass, in seconds. */
+  duration?: number;
+  /** Delay before the sweep starts, in seconds. */
+  delay?: number;
+  /** When `text` is an array, replay the sweep and advance to the next string after each completion. */
+  repeat?: boolean;
+  /** Pause between cycles when `repeat` is `true`, in seconds. */
+  repeatDelay?: number;
+  /** If `true`, the animation starts only after the element enters the viewport. */
+  startOnView?: boolean;
+  /** If `true`, in-view detection fires at most once (no replay on scroll-back). */
+  once?: boolean;
+  /** Additional class names for the animated `span`. */
+  class?: string;
+  /** Use the widest string's width for layout instead of animating width per line. */
+  fixedWidth?: boolean;
+}
+
+const BAND_HALF = 17;
+const SWEEP_START = -BAND_HALF;
+const SWEEP_END = 100 + BAND_HALF;
+
+const sweepEase = (t: number) => (t < 0.5 ? 4 * t ** 3 : 1 - (-2 * t + 2) ** 3 / 2);
+
+function buildGradient(pos: number, colors: string[], textColor: string) {
+  const bandStart = pos - BAND_HALF;
+  const bandEnd = pos + BAND_HALF;
+
+  if (bandStart >= 100) {
+    return `linear-gradient(90deg, ${textColor}, ${textColor})`;
+  }
+  const n = colors.length;
+  const parts: string[] = [];
+
+  if (bandStart > 0) parts.push(`${textColor} 0%`, `${textColor} ${bandStart.toFixed(2)}%`);
+
+  colors.forEach((c, i) => {
+    const pct = n === 1 ? pos : bandStart + (i / (n - 1)) * BAND_HALF * 2;
+    parts.push(`${c} ${pct.toFixed(2)}%`);
+  });
+
+  if (bandEnd < 100) parts.push(`transparent ${bandEnd.toFixed(2)}%`, `transparent 100%`);
+
+  return `linear-gradient(90deg, ${parts.join(", ")})`;
+}
+
+function measureWidths(el: HTMLElement, values: string[]) {
+  const ghost = el.cloneNode() as HTMLElement;
+  Object.assign(ghost.style, {
+    position: "absolute",
+    visibility: "hidden",
+    pointerEvents: "none",
+    width: "auto",
+    whiteSpace: "nowrap",
+  });
+  el.parentElement!.append(ghost);
+  const widths = values.map((t) => {
+    ghost.textContent = t;
+    return ghost.getBoundingClientRect().width;
+  });
+  ghost.remove();
+  return widths;
+}
+
+const props = withDefaults(defineProps<DiaTextRevealProps>(), {
+  colors: () => ["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"],
+  textColor: "var(--foreground)",
+  duration: 1.5,
+  delay: 0,
+  repeat: false,
+  repeatDelay: 0.5,
+  startOnView: true,
+  once: true,
+  fixedWidth: false,
+});
+
+const texts = computed(() => (Array.isArray(props.text) ? props.text : [props.text]));
+const isMulti = computed(() => texts.value.length > 1);
+
+const spanRef = ref<HTMLSpanElement | null>(null);
+const activeIndex = ref(0);
+const measuredWidths = ref<number[]>([]);
+const sweepPos = ref(SWEEP_START);
+
+const backgroundImage = computed(() =>
+  buildGradient(sweepPos.value, props.colors, props.textColor),
+);
+
+let indexRef = 0;
+let hasPlayed = false;
+let timer: ReturnType<typeof setTimeout> | undefined;
+let rafId: number | undefined;
+let observer: IntersectionObserver | undefined;
+let prefersReducedMotion = false;
+
+function stopAnimation() {
+  if (rafId !== undefined) {
+    cancelAnimationFrame(rafId);
+    rafId = undefined;
+  }
+}
+
+function play() {
+  const { duration, delay, repeat, repeatDelay } = props;
+
+  sweepPos.value = SWEEP_START;
+  stopAnimation();
+
+  const durationMs = duration * 1000;
+  const delayMs = delay * 1000;
+  let startTime: number | undefined;
+
+  const step = (now: number) => {
+    if (startTime === undefined) startTime = now;
+    const elapsed = now - startTime - delayMs;
+
+    if (elapsed < 0) {
+      rafId = requestAnimationFrame(step);
+      return;
+    }
+
+    const t = durationMs === 0 ? 1 : Math.min(elapsed / durationMs, 1);
+    sweepPos.value = SWEEP_START + (SWEEP_END - SWEEP_START) * sweepEase(t);
+
+    if (t < 1) {
+      rafId = requestAnimationFrame(step);
+      return;
+    }
+
+    rafId = undefined;
+    if (!repeat) return;
+    timer = setTimeout(
+      () => {
+        const next = (indexRef + 1) % texts.value.length;
+        indexRef = next;
+        activeIndex.value = next;
+        play();
+      },
+      repeatDelay * 1000,
+    );
+  };
+
+  rafId = requestAnimationFrame(step);
+}
+
+function start() {
+  if (prefersReducedMotion) {
+    sweepPos.value = SWEEP_END;
+    return;
+  }
+  if (props.once && hasPlayed) return;
+  hasPlayed = true;
+  play();
+}
+
+function remeasure() {
+  const el = spanRef.value;
+  if (!el || !isMulti.value) return;
+  measuredWidths.value = measureWidths(el, texts.value);
+}
+
+watch(
+  () => (Array.isArray(props.text) ? props.text.join("\0") : props.text),
+  () => remeasure(),
+);
+
+onMounted(() => {
+  prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  remeasure();
+
+  if (prefersReducedMotion) {
+    sweepPos.value = SWEEP_END;
+    return;
+  }
+
+  if (!props.startOnView) {
+    start();
+    return;
+  }
+
+  const el = spanRef.value;
+  if (!el) return;
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          start();
+          if (props.once) observer?.disconnect();
+        }
+      }
+    },
+    { threshold: 0.1 },
+  );
+  observer.observe(el);
+});
+
+onBeforeUnmount(() => {
+  stopAnimation();
+  clearTimeout(timer);
+  observer?.disconnect();
+});
+
+const fixedW = computed(() =>
+  isMulti.value && props.fixedWidth && measuredWidths.value.length > 0
+    ? Math.max(...measuredWidths.value)
+    : undefined,
+);
+
+const animatedW = computed(() =>
+  isMulti.value && !props.fixedWidth && measuredWidths.value[activeIndex.value] != null
+    ? measuredWidths.value[activeIndex.value]
+    : undefined,
+);
+
+const spanStyle = computed(() => {
+  const style: Record<string, string> = {
+    transform: "translateY(-2px)",
+    color: "transparent",
+    backgroundClip: "text",
+    WebkitBackgroundClip: "text",
+    backgroundSize: "100% 100%",
+    backgroundImage: backgroundImage.value,
+  };
+  if (isMulti.value) {
+    style.display = "inline-block";
+    style.overflow = "hidden";
+    style.whiteSpace = "nowrap";
+    style.verticalAlign = "text-center";
+    style.transition = "width 0.4s cubic-bezier(0.4, 0, 0.2, 1)";
+    if (fixedW.value != null) {
+      style.width = `${fixedW.value}px`;
+    } else if (animatedW.value != null) {
+      style.width = `${animatedW.value}px`;
+    }
+  }
+  return style;
+});
+</script>
+
+<template>
+  <span
+    ref="spanRef"
+    :class="cn('align-bottom leading-[100%] text-inherit', props.class)"
+    :style="spanStyle"
+  >
+    {{ texts[activeIndex] }}
+  </span>
+</template>
+```
+
+:::
+
+## Examples
+
+### Custom gradient
+
+Override `colors` for a shorter or softer palette on a single line of text.
+
+<demo src="../../src/example/dia-text-reveal/custom-gradient-demo.vue" srcCode="../../src/spark-ui-demos/dia-text-reveal/custom-gradient.vue" />
+
+### Rotating phrases in a heading
+
+Pass `text` as an array and set `repeat` to cycle strings after each sweep. You can place static words in the same `<h1>` (or paragraph) before the component. Use `fixedWidth` when the strings differ a lot in length and you want to avoid horizontal layout shift.
+
+<demo src="../../src/example/dia-text-reveal/rotating-demo.vue" srcCode="../../src/spark-ui-demos/dia-text-reveal/rotating.vue" />
+
+### Duration and delay
+
+Slow the sweep with `duration`, or add a short `delay` before the band moves.
+
+<demo src="../../src/example/dia-text-reveal/duration-delay-demo.vue" srcCode="../../src/spark-ui-demos/dia-text-reveal/duration-delay.vue" />
+
+## Props
+
+| Prop          | Type                 | Default                                                   | Description                                                                      |
+| ------------- | -------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `text`        | `string \| string[]` | —                                                         | Text to display. Use an array to rotate between strings when `repeat` is on.     |
+| `colors`      | `string[]`           | `["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"]` | Colors in the sweeping gradient band.                                            |
+| `textColor`   | `string`             | `var(--foreground)`                                       | Solid text color after the animation (matches your theme by default).            |
+| `duration`    | `number`             | `1.5`                                                     | Sweep duration in seconds.                                                       |
+| `delay`       | `number`             | `0`                                                       | Delay before the sweep starts, in seconds.                                       |
+| `repeat`      | `boolean`            | `false`                                                   | When `text` is an array, advance to the next string after each cycle.            |
+| `repeatDelay` | `number`             | `0.5`                                                     | Pause in seconds before replaying or advancing (when `repeat` is true).          |
+| `startOnView` | `boolean`            | `true`                                                    | Start the animation when the element enters the viewport.                        |
+| `once`        | `boolean`            | `true`                                                    | Play only the first time (when `startOnView` is used).                           |
+| `class`       | `string`             | —                                                         | Additional CSS classes on the root `span`.                                       |
+| `fixedWidth`  | `boolean`            | `false`                                                   | Lock width to the widest string when `text` is an array to reduce layout shift.  |
+
+## Credits
+
+- Credit to [@chishiyac](https://github.com/chishiyac)
+- Ported from [Magic UI](https://magicui.design)

--- a/docs/content/components/dia-text-reveal.md
+++ b/docs/content/components/dia-text-reveal.md
@@ -88,7 +88,7 @@ function measureWidths(el: HTMLElement, values: string[]) {
 
 const props = withDefaults(defineProps<DiaTextRevealProps>(), {
   colors: () => ["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"],
-  textColor: "var(--foreground)",
+  textColor: "var(--foreground, var(--vp-c-text-1, currentColor))",
   duration: 1.5,
   delay: 0,
   repeat: false,
@@ -303,7 +303,7 @@ Slow the sweep with `duration`, or add a short `delay` before the band moves.
 | ------------- | -------------------- | --------------------------------------------------------- | -------------------------------------------------------------------------------- |
 | `text`        | `string \| string[]` | —                                                         | Text to display. Use an array to rotate between strings when `repeat` is on.     |
 | `colors`      | `string[]`           | `["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"]` | Colors in the sweeping gradient band.                                            |
-| `textColor`   | `string`             | `var(--foreground)`                                       | Solid text color after the animation (matches your theme by default).            |
+| `textColor`   | `string`             | `var(--foreground, var(--vp-c-text-1, currentColor))`     | Solid text color after the animation (matches your theme by default).            |
 | `duration`    | `number`             | `1.5`                                                     | Sweep duration in seconds.                                                       |
 | `delay`       | `number`             | `0`                                                       | Delay before the sweep starts, in seconds.                                       |
 | `repeat`      | `boolean`            | `false`                                                   | When `text` is an array, advance to the next string after each cycle.            |

--- a/docs/src/components/spark-ui/dia-text-reveal/dia-text-reveal.vue
+++ b/docs/src/components/spark-ui/dia-text-reveal/dia-text-reveal.vue
@@ -1,0 +1,262 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface DiaTextRevealProps {
+  /** Text to reveal. Pass multiple strings to rotate when `repeat` is `true`. */
+  text: string | string[];
+  /** Colors sampled across the moving gradient band. */
+  colors?: string[];
+  /** CSS color for revealed text after the sweep and for leading/trailing regions. */
+  textColor?: string;
+  /** Duration of one sweep pass, in seconds. */
+  duration?: number;
+  /** Delay before the sweep starts, in seconds. */
+  delay?: number;
+  /** When `text` is an array, replay the sweep and advance to the next string after each completion. */
+  repeat?: boolean;
+  /** Pause between cycles when `repeat` is `true`, in seconds. */
+  repeatDelay?: number;
+  /** If `true`, the animation starts only after the element enters the viewport. */
+  startOnView?: boolean;
+  /** If `true`, in-view detection fires at most once (no replay on scroll-back). */
+  once?: boolean;
+  /** Additional class names for the animated `span`. */
+  class?: string;
+  /** Use the widest string's width for layout instead of animating width per line. */
+  fixedWidth?: boolean;
+}
+
+const BAND_HALF = 17;
+const SWEEP_START = -BAND_HALF;
+const SWEEP_END = 100 + BAND_HALF;
+
+const sweepEase = (t: number) => (t < 0.5 ? 4 * t ** 3 : 1 - (-2 * t + 2) ** 3 / 2);
+
+function buildGradient(pos: number, colors: string[], textColor: string) {
+  const bandStart = pos - BAND_HALF;
+  const bandEnd = pos + BAND_HALF;
+
+  if (bandStart >= 100) {
+    return `linear-gradient(90deg, ${textColor}, ${textColor})`;
+  }
+  const n = colors.length;
+  const parts: string[] = [];
+
+  if (bandStart > 0) parts.push(`${textColor} 0%`, `${textColor} ${bandStart.toFixed(2)}%`);
+
+  colors.forEach((c, i) => {
+    const pct = n === 1 ? pos : bandStart + (i / (n - 1)) * BAND_HALF * 2;
+    parts.push(`${c} ${pct.toFixed(2)}%`);
+  });
+
+  if (bandEnd < 100) parts.push(`transparent ${bandEnd.toFixed(2)}%`, `transparent 100%`);
+
+  return `linear-gradient(90deg, ${parts.join(", ")})`;
+}
+
+function measureWidths(el: HTMLElement, values: string[]) {
+  const ghost = el.cloneNode() as HTMLElement;
+  Object.assign(ghost.style, {
+    position: "absolute",
+    visibility: "hidden",
+    pointerEvents: "none",
+    width: "auto",
+    whiteSpace: "nowrap",
+  });
+  el.parentElement!.append(ghost);
+  const widths = values.map((t) => {
+    ghost.textContent = t;
+    return ghost.getBoundingClientRect().width;
+  });
+  ghost.remove();
+  return widths;
+}
+
+const props = withDefaults(defineProps<DiaTextRevealProps>(), {
+  colors: () => ["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"],
+  textColor: "var(--foreground)",
+  duration: 1.5,
+  delay: 0,
+  repeat: false,
+  repeatDelay: 0.5,
+  startOnView: true,
+  once: true,
+  fixedWidth: false,
+});
+
+const texts = computed(() => (Array.isArray(props.text) ? props.text : [props.text]));
+const isMulti = computed(() => texts.value.length > 1);
+
+const spanRef = ref<HTMLSpanElement | null>(null);
+const activeIndex = ref(0);
+const measuredWidths = ref<number[]>([]);
+const sweepPos = ref(SWEEP_START);
+
+const backgroundImage = computed(() =>
+  buildGradient(sweepPos.value, props.colors, props.textColor),
+);
+
+let indexRef = 0;
+let hasPlayed = false;
+let timer: ReturnType<typeof setTimeout> | undefined;
+let rafId: number | undefined;
+let observer: IntersectionObserver | undefined;
+let prefersReducedMotion = false;
+
+function stopAnimation() {
+  if (rafId !== undefined) {
+    cancelAnimationFrame(rafId);
+    rafId = undefined;
+  }
+}
+
+function play() {
+  const { duration, delay, repeat, repeatDelay } = props;
+
+  sweepPos.value = SWEEP_START;
+  stopAnimation();
+
+  const durationMs = duration * 1000;
+  const delayMs = delay * 1000;
+  let startTime: number | undefined;
+
+  const step = (now: number) => {
+    if (startTime === undefined) startTime = now;
+    const elapsed = now - startTime - delayMs;
+
+    if (elapsed < 0) {
+      rafId = requestAnimationFrame(step);
+      return;
+    }
+
+    const t = durationMs === 0 ? 1 : Math.min(elapsed / durationMs, 1);
+    sweepPos.value = SWEEP_START + (SWEEP_END - SWEEP_START) * sweepEase(t);
+
+    if (t < 1) {
+      rafId = requestAnimationFrame(step);
+      return;
+    }
+
+    rafId = undefined;
+    if (!repeat) return;
+    timer = setTimeout(
+      () => {
+        const next = (indexRef + 1) % texts.value.length;
+        indexRef = next;
+        activeIndex.value = next;
+        play();
+      },
+      repeatDelay * 1000,
+    );
+  };
+
+  rafId = requestAnimationFrame(step);
+}
+
+function start() {
+  if (prefersReducedMotion) {
+    sweepPos.value = SWEEP_END;
+    return;
+  }
+  if (props.once && hasPlayed) return;
+  hasPlayed = true;
+  play();
+}
+
+function remeasure() {
+  const el = spanRef.value;
+  if (!el || !isMulti.value) return;
+  measuredWidths.value = measureWidths(el, texts.value);
+}
+
+watch(
+  () => (Array.isArray(props.text) ? props.text.join("\0") : props.text),
+  () => remeasure(),
+);
+
+onMounted(() => {
+  prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  remeasure();
+
+  if (prefersReducedMotion) {
+    sweepPos.value = SWEEP_END;
+    return;
+  }
+
+  if (!props.startOnView) {
+    start();
+    return;
+  }
+
+  const el = spanRef.value;
+  if (!el) return;
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          start();
+          if (props.once) observer?.disconnect();
+        }
+      }
+    },
+    { threshold: 0.1 },
+  );
+  observer.observe(el);
+});
+
+onBeforeUnmount(() => {
+  stopAnimation();
+  clearTimeout(timer);
+  observer?.disconnect();
+});
+
+const fixedW = computed(() =>
+  isMulti.value && props.fixedWidth && measuredWidths.value.length > 0
+    ? Math.max(...measuredWidths.value)
+    : undefined,
+);
+
+const animatedW = computed(() =>
+  isMulti.value && !props.fixedWidth && measuredWidths.value[activeIndex.value] != null
+    ? measuredWidths.value[activeIndex.value]
+    : undefined,
+);
+
+const spanStyle = computed(() => {
+  const style: Record<string, string> = {
+    transform: "translateY(-2px)",
+    color: "transparent",
+    backgroundClip: "text",
+    WebkitBackgroundClip: "text",
+    backgroundSize: "100% 100%",
+    backgroundImage: backgroundImage.value,
+  };
+  if (isMulti.value) {
+    style.display = "inline-block";
+    style.overflow = "hidden";
+    style.whiteSpace = "nowrap";
+    style.verticalAlign = "text-center";
+    style.transition = "width 0.4s cubic-bezier(0.4, 0, 0.2, 1)";
+    if (fixedW.value != null) {
+      style.width = `${fixedW.value}px`;
+    } else if (animatedW.value != null) {
+      style.width = `${animatedW.value}px`;
+    }
+  }
+  return style;
+});
+</script>
+
+<template>
+  <span
+    ref="spanRef"
+    :class="cn('align-bottom leading-[100%] text-inherit', props.class)"
+    :style="spanStyle"
+  >
+    {{ texts[activeIndex] }}
+  </span>
+</template>

--- a/docs/src/components/spark-ui/dia-text-reveal/dia-text-reveal.vue
+++ b/docs/src/components/spark-ui/dia-text-reveal/dia-text-reveal.vue
@@ -75,7 +75,7 @@ function measureWidths(el: HTMLElement, values: string[]) {
 
 const props = withDefaults(defineProps<DiaTextRevealProps>(), {
   colors: () => ["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"],
-  textColor: "var(--foreground)",
+  textColor: "var(--foreground, var(--vp-c-text-1, currentColor))",
   duration: 1.5,
   delay: 0,
   repeat: false,

--- a/docs/src/example/dia-text-reveal/custom-gradient-demo.vue
+++ b/docs/src/example/dia-text-reveal/custom-gradient-demo.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import DiaTextReveal from "./dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="flex min-h-56 items-center justify-center p-8">
+    <DiaTextReveal
+      class="text-4xl font-bold tracking-tight"
+      :colors="['#22d3ee', '#818cf8', '#f472b6', '#34d399']"
+      text="Design systems"
+    />
+  </div>
+</template>

--- a/docs/src/example/dia-text-reveal/demo.vue
+++ b/docs/src/example/dia-text-reveal/demo.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import DiaTextReveal from "./dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="flex min-h-64 items-center justify-center p-8">
+    <DiaTextReveal
+      class="text-4xl font-bold tracking-tight"
+      text="Magic UI"
+      :colors="['#A97CF8', '#F38CB8', '#FDCC92']"
+    />
+  </div>
+</template>

--- a/docs/src/example/dia-text-reveal/dia-text-reveal.vue
+++ b/docs/src/example/dia-text-reveal/dia-text-reveal.vue
@@ -1,0 +1,262 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { cn } from "../../lib/utils";
+
+interface DiaTextRevealProps {
+  /** Text to reveal. Pass multiple strings to rotate when `repeat` is `true`. */
+  text: string | string[];
+  /** Colors sampled across the moving gradient band. */
+  colors?: string[];
+  /** CSS color for revealed text after the sweep and for leading/trailing regions. */
+  textColor?: string;
+  /** Duration of one sweep pass, in seconds. */
+  duration?: number;
+  /** Delay before the sweep starts, in seconds. */
+  delay?: number;
+  /** When `text` is an array, replay the sweep and advance to the next string after each completion. */
+  repeat?: boolean;
+  /** Pause between cycles when `repeat` is `true`, in seconds. */
+  repeatDelay?: number;
+  /** If `true`, the animation starts only after the element enters the viewport. */
+  startOnView?: boolean;
+  /** If `true`, in-view detection fires at most once (no replay on scroll-back). */
+  once?: boolean;
+  /** Additional class names for the animated `span`. */
+  class?: string;
+  /** Use the widest string's width for layout instead of animating width per line. */
+  fixedWidth?: boolean;
+}
+
+const BAND_HALF = 17;
+const SWEEP_START = -BAND_HALF;
+const SWEEP_END = 100 + BAND_HALF;
+
+const sweepEase = (t: number) => (t < 0.5 ? 4 * t ** 3 : 1 - (-2 * t + 2) ** 3 / 2);
+
+function buildGradient(pos: number, colors: string[], textColor: string) {
+  const bandStart = pos - BAND_HALF;
+  const bandEnd = pos + BAND_HALF;
+
+  if (bandStart >= 100) {
+    return `linear-gradient(90deg, ${textColor}, ${textColor})`;
+  }
+  const n = colors.length;
+  const parts: string[] = [];
+
+  if (bandStart > 0) parts.push(`${textColor} 0%`, `${textColor} ${bandStart.toFixed(2)}%`);
+
+  colors.forEach((c, i) => {
+    const pct = n === 1 ? pos : bandStart + (i / (n - 1)) * BAND_HALF * 2;
+    parts.push(`${c} ${pct.toFixed(2)}%`);
+  });
+
+  if (bandEnd < 100) parts.push(`transparent ${bandEnd.toFixed(2)}%`, `transparent 100%`);
+
+  return `linear-gradient(90deg, ${parts.join(", ")})`;
+}
+
+function measureWidths(el: HTMLElement, values: string[]) {
+  const ghost = el.cloneNode() as HTMLElement;
+  Object.assign(ghost.style, {
+    position: "absolute",
+    visibility: "hidden",
+    pointerEvents: "none",
+    width: "auto",
+    whiteSpace: "nowrap",
+  });
+  el.parentElement!.append(ghost);
+  const widths = values.map((t) => {
+    ghost.textContent = t;
+    return ghost.getBoundingClientRect().width;
+  });
+  ghost.remove();
+  return widths;
+}
+
+const props = withDefaults(defineProps<DiaTextRevealProps>(), {
+  colors: () => ["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"],
+  textColor: "var(--foreground)",
+  duration: 1.5,
+  delay: 0,
+  repeat: false,
+  repeatDelay: 0.5,
+  startOnView: true,
+  once: true,
+  fixedWidth: false,
+});
+
+const texts = computed(() => (Array.isArray(props.text) ? props.text : [props.text]));
+const isMulti = computed(() => texts.value.length > 1);
+
+const spanRef = ref<HTMLSpanElement | null>(null);
+const activeIndex = ref(0);
+const measuredWidths = ref<number[]>([]);
+const sweepPos = ref(SWEEP_START);
+
+const backgroundImage = computed(() =>
+  buildGradient(sweepPos.value, props.colors, props.textColor),
+);
+
+let indexRef = 0;
+let hasPlayed = false;
+let timer: ReturnType<typeof setTimeout> | undefined;
+let rafId: number | undefined;
+let observer: IntersectionObserver | undefined;
+let prefersReducedMotion = false;
+
+function stopAnimation() {
+  if (rafId !== undefined) {
+    cancelAnimationFrame(rafId);
+    rafId = undefined;
+  }
+}
+
+function play() {
+  const { duration, delay, repeat, repeatDelay } = props;
+
+  sweepPos.value = SWEEP_START;
+  stopAnimation();
+
+  const durationMs = duration * 1000;
+  const delayMs = delay * 1000;
+  let startTime: number | undefined;
+
+  const step = (now: number) => {
+    if (startTime === undefined) startTime = now;
+    const elapsed = now - startTime - delayMs;
+
+    if (elapsed < 0) {
+      rafId = requestAnimationFrame(step);
+      return;
+    }
+
+    const t = durationMs === 0 ? 1 : Math.min(elapsed / durationMs, 1);
+    sweepPos.value = SWEEP_START + (SWEEP_END - SWEEP_START) * sweepEase(t);
+
+    if (t < 1) {
+      rafId = requestAnimationFrame(step);
+      return;
+    }
+
+    rafId = undefined;
+    if (!repeat) return;
+    timer = setTimeout(
+      () => {
+        const next = (indexRef + 1) % texts.value.length;
+        indexRef = next;
+        activeIndex.value = next;
+        play();
+      },
+      repeatDelay * 1000,
+    );
+  };
+
+  rafId = requestAnimationFrame(step);
+}
+
+function start() {
+  if (prefersReducedMotion) {
+    sweepPos.value = SWEEP_END;
+    return;
+  }
+  if (props.once && hasPlayed) return;
+  hasPlayed = true;
+  play();
+}
+
+function remeasure() {
+  const el = spanRef.value;
+  if (!el || !isMulti.value) return;
+  measuredWidths.value = measureWidths(el, texts.value);
+}
+
+watch(
+  () => (Array.isArray(props.text) ? props.text.join("\0") : props.text),
+  () => remeasure(),
+);
+
+onMounted(() => {
+  prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  remeasure();
+
+  if (prefersReducedMotion) {
+    sweepPos.value = SWEEP_END;
+    return;
+  }
+
+  if (!props.startOnView) {
+    start();
+    return;
+  }
+
+  const el = spanRef.value;
+  if (!el) return;
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          start();
+          if (props.once) observer?.disconnect();
+        }
+      }
+    },
+    { threshold: 0.1 },
+  );
+  observer.observe(el);
+});
+
+onBeforeUnmount(() => {
+  stopAnimation();
+  clearTimeout(timer);
+  observer?.disconnect();
+});
+
+const fixedW = computed(() =>
+  isMulti.value && props.fixedWidth && measuredWidths.value.length > 0
+    ? Math.max(...measuredWidths.value)
+    : undefined,
+);
+
+const animatedW = computed(() =>
+  isMulti.value && !props.fixedWidth && measuredWidths.value[activeIndex.value] != null
+    ? measuredWidths.value[activeIndex.value]
+    : undefined,
+);
+
+const spanStyle = computed(() => {
+  const style: Record<string, string> = {
+    transform: "translateY(-2px)",
+    color: "transparent",
+    backgroundClip: "text",
+    WebkitBackgroundClip: "text",
+    backgroundSize: "100% 100%",
+    backgroundImage: backgroundImage.value,
+  };
+  if (isMulti.value) {
+    style.display = "inline-block";
+    style.overflow = "hidden";
+    style.whiteSpace = "nowrap";
+    style.verticalAlign = "text-center";
+    style.transition = "width 0.4s cubic-bezier(0.4, 0, 0.2, 1)";
+    if (fixedW.value != null) {
+      style.width = `${fixedW.value}px`;
+    } else if (animatedW.value != null) {
+      style.width = `${animatedW.value}px`;
+    }
+  }
+  return style;
+});
+</script>
+
+<template>
+  <span
+    ref="spanRef"
+    :class="cn('align-bottom leading-[100%] text-inherit', props.class)"
+    :style="spanStyle"
+  >
+    {{ texts[activeIndex] }}
+  </span>
+</template>

--- a/docs/src/example/dia-text-reveal/dia-text-reveal.vue
+++ b/docs/src/example/dia-text-reveal/dia-text-reveal.vue
@@ -75,7 +75,7 @@ function measureWidths(el: HTMLElement, values: string[]) {
 
 const props = withDefaults(defineProps<DiaTextRevealProps>(), {
   colors: () => ["#c679c4", "#fa3d1d", "#ffb005", "#e1e1fe", "#0358f7"],
-  textColor: "var(--foreground)",
+  textColor: "var(--foreground, var(--vp-c-text-1, currentColor))",
   duration: 1.5,
   delay: 0,
   repeat: false,

--- a/docs/src/example/dia-text-reveal/duration-delay-demo.vue
+++ b/docs/src/example/dia-text-reveal/duration-delay-demo.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import DiaTextReveal from "./dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="flex min-h-56 items-center justify-center p-8">
+    <DiaTextReveal
+      class="text-4xl font-bold tracking-tight"
+      :colors="['#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7']"
+      :delay="0.35"
+      :duration="2.4"
+      text="Made with care"
+    />
+  </div>
+</template>

--- a/docs/src/example/dia-text-reveal/rotating-demo.vue
+++ b/docs/src/example/dia-text-reveal/rotating-demo.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import DiaTextReveal from "./dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="text-foreground flex min-h-64 items-center justify-center p-8">
+    <h1 class="text-center text-3xl font-semibold tracking-tight md:text-4xl">
+      Learn to
+      <DiaTextReveal
+        repeat
+        :repeat-delay="1.2"
+        :text="['build faster', 'ship smarter', 'scale easier']"
+      />
+    </h1>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/dia-text-reveal/custom-gradient.vue
+++ b/docs/src/spark-ui-demos/dia-text-reveal/custom-gradient.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import DiaTextReveal from "../../components/spark-ui/dia-text-reveal/dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="flex min-h-56 items-center justify-center p-8">
+    <DiaTextReveal
+      class="text-4xl font-bold tracking-tight"
+      :colors="['#22d3ee', '#818cf8', '#f472b6', '#34d399']"
+      text="Design systems"
+    />
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/dia-text-reveal/dia-text-reveal.vue
+++ b/docs/src/spark-ui-demos/dia-text-reveal/dia-text-reveal.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import DiaTextReveal from "../../components/spark-ui/dia-text-reveal/dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="flex min-h-64 items-center justify-center p-8">
+    <DiaTextReveal
+      class="text-4xl font-bold tracking-tight"
+      text="Magic UI"
+      :colors="['#A97CF8', '#F38CB8', '#FDCC92']"
+    />
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/dia-text-reveal/duration-delay.vue
+++ b/docs/src/spark-ui-demos/dia-text-reveal/duration-delay.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import DiaTextReveal from "../../components/spark-ui/dia-text-reveal/dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="flex min-h-56 items-center justify-center p-8">
+    <DiaTextReveal
+      class="text-4xl font-bold tracking-tight"
+      :colors="['#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7']"
+      :delay="0.35"
+      :duration="2.4"
+      text="Made with care"
+    />
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/dia-text-reveal/rotating.vue
+++ b/docs/src/spark-ui-demos/dia-text-reveal/rotating.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import DiaTextReveal from "../../components/spark-ui/dia-text-reveal/dia-text-reveal.vue";
+</script>
+
+<template>
+  <div class="text-foreground flex min-h-64 items-center justify-center p-8">
+    <h1 class="text-center text-3xl font-semibold tracking-tight md:text-4xl">
+      Learn to
+      <DiaTextReveal
+        repeat
+        :repeat-delay="1.2"
+        :text="['build faster', 'ship smarter', 'scale easier']"
+      />
+    </h1>
+  </div>
+</template>

--- a/tests/dia-text-reveal/dia-text-reveal.spec.ts
+++ b/tests/dia-text-reveal/dia-text-reveal.spec.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+/// <reference lib="dom" />
+import { mount } from "@vue/test-utils";
+import { beforeAll, expect, it } from "vite-plus/test";
+import DiaTextReveal from "../../docs/src/components/spark-ui/dia-text-reveal/dia-text-reveal.vue";
+
+beforeAll(() => {
+  if (!("IntersectionObserver" in globalThis)) {
+    globalThis.IntersectionObserver = class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof IntersectionObserver;
+  }
+  if (!globalThis.matchMedia) {
+    globalThis.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+      dispatchEvent() {
+        return false;
+      },
+      onchange: null,
+    })) as unknown as typeof globalThis.matchMedia;
+  }
+  globalThis.requestAnimationFrame ??= ((cb: FrameRequestCallback) =>
+    setTimeout(() => cb(0), 0) as unknown as number) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame ??= ((id: number) =>
+    clearTimeout(id)) as typeof cancelAnimationFrame;
+});
+
+it("renders single text content", () => {
+  const wrapper = mount(DiaTextReveal, { props: { text: "Magic UI" } });
+  expect(wrapper.text()).toBe("Magic UI");
+  expect(wrapper.element.tagName).toBe("SPAN");
+});
+
+it("renders the first entry when text is an array", () => {
+  const wrapper = mount(DiaTextReveal, {
+    props: { text: ["one", "two", "three"] },
+  });
+  expect(wrapper.text()).toBe("one");
+});
+
+it("applies base classes and text-reveal styling", () => {
+  const wrapper = mount(DiaTextReveal, { props: { text: "Hello" } });
+  const el = wrapper.get("span");
+  expect(el.classes()).toContain("align-bottom");
+  const style = el.attributes("style") ?? "";
+  expect(style).toContain("background-clip: text");
+  expect(style).toContain("linear-gradient");
+});
+
+it("merges a custom class", () => {
+  const wrapper = mount(DiaTextReveal, {
+    props: { text: "Hello", class: "text-4xl font-bold" },
+  });
+  expect(wrapper.get("span").classes()).toContain("text-4xl");
+  expect(wrapper.get("span").classes()).toContain("font-bold");
+});
+
+it("uses inline-block layout for multi-text (rotation)", () => {
+  const wrapper = mount(DiaTextReveal, {
+    props: { text: ["a", "bb"] },
+  });
+  const style = wrapper.get("span").attributes("style") ?? "";
+  expect(style).toContain("display: inline-block");
+  expect(style).toContain("white-space: nowrap");
+});
+
+it("does not apply inline-block layout for single text", () => {
+  const wrapper = mount(DiaTextReveal, { props: { text: "solo" } });
+  const style = wrapper.get("span").attributes("style") ?? "";
+  expect(style).not.toContain("display: inline-block");
+});
+
+it("includes custom colors in the gradient", async () => {
+  const wrapper = mount(DiaTextReveal, {
+    props: { text: "Hi", colors: ["#123456", "#abcdef"], startOnView: false },
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  const style = wrapper.get("span").attributes("style") ?? "";
+  expect(style.toLowerCase()).toContain("#123456");
+});
+
+it("settles on textColor when reduced motion is preferred", async () => {
+  globalThis.matchMedia = ((query: string) => ({
+    matches: true,
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    dispatchEvent() {
+      return false;
+    },
+    onchange: null,
+  })) as unknown as typeof globalThis.matchMedia;
+  const wrapper = mount(DiaTextReveal, {
+    props: { text: "Reduced", textColor: "rgb(1, 2, 3)" },
+  });
+  await wrapper.vm.$nextTick();
+  const style = wrapper.get("span").attributes("style") ?? "";
+  expect(style).toContain("rgb(1, 2, 3)");
+  globalThis.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    dispatchEvent() {
+      return false;
+    },
+    onchange: null,
+  })) as unknown as typeof globalThis.matchMedia;
+});


### PR DESCRIPTION
Ports Magic UI's **Dia Text Reveal** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/dia-text-reveal/dia-text-reveal.vue` — gradient sweep text reveal with the exact upstream gradient math (band half-width, per-color stops), custom sweep easing, `delay`, `duration`, `repeat`/`repeatDelay` text cycling, `fixedWidth`, and reduced-motion support
- framer-motion primitives translated idiomatically: rAF loop for the sweep, `IntersectionObserver` for `useInView(once)`, `matchMedia` for `useReducedMotion`, CSS transition for the width animation; all SSR-safe and cleaned up on unmount
- 4 live demos (default, custom gradient, rotating texts, duration/delay) + copy-paste sources
- Docs page (installation, examples, props table); one-line sidebar entry
- 8 passing tests in `tests/dia-text-reveal/`

## Verification
- `pnpm lint` ✅
- `vue-tsc` docs typecheck ✅ (`scripts/tsconfig.json` step fails on `dev` too — pre-existing)
- `pnpm dlx tsx scripts/validate-component.ts` ✅
- Tests ✅ (8 passed)