### PR TITLE
feat(dotted-map): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,6 +19,7 @@ const newComponents = [
 	{ text: "Aurora Text", link: "/content/components/aurora.md" },
 	{ text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
+	{ text: "Dotted Map", link: "/content/components/dotted-map.md" },
 ];
 
 const components = [

--- a/docs/content/components/dotted-map.md
+++ b/docs/content/components/dotted-map.md
@@ -1,0 +1,307 @@
+# Dotted Map
+
+A component with a svg dotted map.
+
+<demo src="../../src/example/dotted-map/demo.vue" srcCode="../../src/spark-ui-demos/dotted-map/dotted-map.vue" />
+
+## Installation
+
+Install the following dependency:
+
+```bash
+npm install svg-dotted-map
+```
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [dotted-map.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import { createMap } from "svg-dotted-map";
+import { cn } from "@/lib/utils";
+
+export interface Marker {
+  lat: number;
+  lng: number;
+  size?: number;
+  pulse?: boolean;
+  [key: string]: unknown;
+}
+
+/** Markers returned by addMarkers have lat/lng removed; x, y and other props remain. */
+export type MapMarker = Omit<Marker, "lat" | "lng"> & {
+  x: number;
+  y: number;
+};
+
+interface DottedMapProps {
+  class?: string;
+  width?: number;
+  height?: number;
+  mapSamples?: number;
+  markers?: Marker[];
+  dotColor?: string;
+  markerColor?: string;
+  dotRadius?: number;
+  stagger?: boolean;
+  pulse?: boolean;
+  [key: string]: unknown;
+}
+
+const props = withDefaults(defineProps<DottedMapProps>(), {
+  width: 150,
+  height: 75,
+  mapSamples: 5000,
+  markers: () => [],
+  dotColor: "currentColor",
+  markerColor: "#FF6900",
+  dotRadius: 0.2,
+  stagger: true,
+  pulse: false,
+});
+
+defineSlots<{
+  marker?: (props: {
+    marker: MapMarker;
+    index: number;
+    x: number;
+    y: number;
+    r: number;
+  }) => unknown;
+}>();
+
+const map = computed(() =>
+  createMap({
+    width: props.width,
+    height: props.height,
+    mapSamples: props.mapSamples,
+  }),
+);
+
+const points = computed(() => map.value.points);
+
+const processedMarkers = computed(
+  () => map.value.addMarkers(props.markers) as MapMarker[],
+);
+
+// Compute stagger helpers in a single, simple pass.
+const stagger = computed(() => {
+  const sorted = [...points.value].sort((a, b) => a.y - b.y || a.x - b.x);
+  const rowMap = new Map<number, number>();
+  let step = 0;
+  let prevY = Number.NaN;
+  let prevXInRow = Number.NaN;
+
+  for (const p of sorted) {
+    if (p.y !== prevY) {
+      // new row
+      prevY = p.y;
+      prevXInRow = Number.NaN;
+      if (!rowMap.has(p.y)) rowMap.set(p.y, rowMap.size);
+    }
+    if (!Number.isNaN(prevXInRow)) {
+      const delta = p.x - prevXInRow;
+      if (delta > 0) step = step === 0 ? delta : Math.min(step, delta);
+    }
+    prevXInRow = p.x;
+  }
+
+  return { xStep: step || 1, yToRowIndex: rowMap };
+});
+
+function rowOffset(y: number) {
+  const rowIndex = stagger.value.yToRowIndex.get(y) ?? 0;
+  return props.stagger && rowIndex % 2 === 1 ? stagger.value.xStep / 2 : 0;
+}
+
+const renderedMarkers = computed(() =>
+  processedMarkers.value.map((marker, index) => {
+    const offsetX = rowOffset(marker.y);
+    const x = marker.x + offsetX;
+    const y = marker.y;
+    const r = marker.size ?? props.dotRadius;
+    const shouldPulse = props.pulse
+      ? marker.pulse !== false
+      : marker.pulse === true;
+    const pulseTo = r * 2.8;
+    return { marker: { ...marker, x, y }, index, x, y, r, shouldPulse, pulseTo };
+  }),
+);
+</script>
+
+<template>
+  <svg
+    :viewBox="`0 0 ${props.width} ${props.height}`"
+    :class="cn('text-gray-500 dark:text-gray-500', props.class)"
+    style="width: 100%; height: 100%"
+  >
+    <circle
+      v-for="(point, index) in points"
+      :key="`${point.x}-${point.y}-${index}`"
+      :cx="point.x + rowOffset(point.y)"
+      :cy="point.y"
+      :r="props.dotRadius"
+      :fill="props.dotColor"
+    />
+
+    <g
+      v-for="item in renderedMarkers"
+      :key="`${item.x}-${item.y}-${item.index}`"
+    >
+      <circle :cx="item.x" :cy="item.y" :r="item.r" :fill="props.markerColor" />
+
+      <g v-if="item.shouldPulse" pointer-events="none">
+        <circle
+          :cx="item.x"
+          :cy="item.y"
+          :r="item.r"
+          fill="none"
+          :stroke="props.markerColor"
+          :stroke-opacity="1"
+          :stroke-width="0.35"
+        >
+          <animate
+            attributeName="r"
+            :values="`${item.r};${item.pulseTo}`"
+            dur="1.4s"
+            repeatCount="indefinite"
+          />
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            dur="1.4s"
+            repeatCount="indefinite"
+          />
+        </circle>
+        <circle
+          :cx="item.x"
+          :cy="item.y"
+          :r="item.r"
+          fill="none"
+          :stroke="props.markerColor"
+          :stroke-opacity="0.9"
+          :stroke-width="0.3"
+        >
+          <animate
+            attributeName="r"
+            :values="`${item.r};${item.pulseTo}`"
+            dur="1.4s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+          <animate
+            attributeName="opacity"
+            values="0.9;0"
+            dur="1.4s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+        </circle>
+      </g>
+
+      <slot
+        name="marker"
+        :marker="item.marker"
+        :index="item.index"
+        :x="item.x"
+        :y="item.y"
+        :r="item.r"
+      />
+    </g>
+  </svg>
+</template>
+```
+
+:::
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import DottedMap from "@/components/ui/dotted-map.vue";
+</script>
+
+<template>
+  <div class="relative h-[400px] w-full overflow-hidden rounded-xl border">
+    <DottedMap />
+  </div>
+</template>
+```
+
+### With Custom Markers
+
+Use the `marker` scoped slot (the idiomatic Vue equivalent of Magic UI's
+`renderMarkerOverlay` render prop) to render custom overlays. The slot exposes
+`marker`, `index`, `x`, `y` and `r`.
+
+```vue
+<script setup lang="ts">
+import DottedMap from "@/components/ui/dotted-map.vue";
+import type { Marker } from "@/components/ui/dotted-map.vue";
+
+type MyMarker = Marker & { label: string };
+
+const markers: MyMarker[] = [
+  { lat: 37.5665, lng: 126.978, size: 2.8, label: "Seoul" },
+];
+</script>
+
+<template>
+  <DottedMap :markers="markers">
+    <template #marker="{ marker, x, y }">
+      <text :x="x" :y="y">{{ (marker as MyMarker).label }}</text>
+    </template>
+  </DottedMap>
+</template>
+```
+
+## Examples
+
+### Smaller Dots
+
+<demo src="../../src/example/dotted-map/demo-2.vue" srcCode="../../src/spark-ui-demos/dotted-map/smaller-dots.vue" />
+
+### Pulse Marker
+
+<demo src="../../src/example/dotted-map/demo-3.vue" srcCode="../../src/spark-ui-demos/dotted-map/pulse-marker.vue" />
+
+Set `pulse` on `DottedMap` to animate all markers (and use `marker.pulse = false`
+to opt out per marker). Without the `pulse` prop, only markers with
+`marker.pulse = true` will pulse.
+
+## Props
+
+| Prop          | Type       | Default          | Description                                                     |
+| ------------- | ---------- | ---------------- | --------------------------------------------------------------- |
+| `width`       | `number`   | `150`            | Width of the SVG map.                                           |
+| `height`      | `number`   | `75`             | Height of the SVG map.                                          |
+| `mapSamples`  | `number`   | `5000`           | Number of sample points for map generation.                    |
+| `markers`     | `Marker[]` | `[]`             | Array of markers to display on the map.                        |
+| `dotColor`    | `string`   | `"currentColor"` | Color of the map dots.                                          |
+| `markerColor` | `string`   | `"#FF6900"`      | Color of the markers.                                           |
+| `dotRadius`   | `number`   | `0.2`            | Radius of the map dots.                                         |
+| `stagger`     | `boolean`  | `true`           | Whether to stagger dots in alternating rows for visual effect. |
+| `pulse`       | `boolean`  | `false`          | Enables built-in pulse animation for markers.                  |
+| `class`       | `string`   | `-`              | Additional class names applied to the SVG.                     |
+
+## Slots
+
+| Slot     | Props                          | Description                                     |
+| -------- | ------------------------------ | ----------------------------------------------- |
+| `marker` | `{ marker, index, x, y, r }`   | Custom overlay rendered for each marker.        |
+
+## Types
+
+### Marker
+
+```ts
+export interface Marker {
+  lat: number;
+  lng: number;
+  size?: number;
+  pulse?: boolean;
+  [key: string]: unknown;
+}
+```

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
     "cobe": "^0.6.3",
     "fs-extra": "^11.2.0",
     "markdown-it": "^14.1.0",
+    "svg-dotted-map": "^2.1.0",
     "tailwind-merge": "^2.5.3",
     "vitepress-plugin-group-icons": "^1.2.4",
     "vue-use-spring": "^0.3.3"

--- a/docs/src/components/spark-ui/dotted-map/dotted-map.vue
+++ b/docs/src/components/spark-ui/dotted-map/dotted-map.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { createMap } from "svg-dotted-map";
+import { cn } from "../../../lib/utils";
+
+export interface Marker {
+  lat: number;
+  lng: number;
+  size?: number;
+  pulse?: boolean;
+  [key: string]: any;
+}
+
+/** Markers returned by addMarkers have lat/lng removed; x, y and other props remain. */
+export type MapMarker = Omit<Marker, "lat" | "lng"> & {
+  x: number;
+  y: number;
+};
+
+interface DottedMapProps {
+  class?: string;
+  width?: number;
+  height?: number;
+  mapSamples?: number;
+  markers?: Marker[];
+  dotColor?: string;
+  markerColor?: string;
+  dotRadius?: number;
+  stagger?: boolean;
+  pulse?: boolean;
+  [key: string]: any;
+}
+
+const props = withDefaults(defineProps<DottedMapProps>(), {
+  width: 150,
+  height: 75,
+  mapSamples: 5000,
+  markers: () => [],
+  dotColor: "currentColor",
+  markerColor: "#FF6900",
+  dotRadius: 0.2,
+  stagger: true,
+  pulse: false,
+});
+
+defineSlots<{
+  marker?: (props: {
+    marker: MapMarker;
+    index: number;
+    x: number;
+    y: number;
+    r: number;
+  }) => unknown;
+}>();
+
+const map = computed(() =>
+  createMap({
+    width: props.width,
+    height: props.height,
+    mapSamples: props.mapSamples,
+  }),
+);
+
+const points = computed(() => map.value.points);
+
+const processedMarkers = computed(
+  () => map.value.addMarkers(props.markers) as MapMarker[],
+);
+
+// Compute stagger helpers in a single, simple pass.
+const stagger = computed(() => {
+  const sorted = [...points.value].sort((a, b) => a.y - b.y || a.x - b.x);
+  const rowMap = new Map<number, number>();
+  let step = 0;
+  let prevY = Number.NaN;
+  let prevXInRow = Number.NaN;
+
+  for (const p of sorted) {
+    if (p.y !== prevY) {
+      // new row
+      prevY = p.y;
+      prevXInRow = Number.NaN;
+      if (!rowMap.has(p.y)) rowMap.set(p.y, rowMap.size);
+    }
+    if (!Number.isNaN(prevXInRow)) {
+      const delta = p.x - prevXInRow;
+      if (delta > 0) step = step === 0 ? delta : Math.min(step, delta);
+    }
+    prevXInRow = p.x;
+  }
+
+  return { xStep: step || 1, yToRowIndex: rowMap };
+});
+
+function rowOffset(y: number) {
+  const rowIndex = stagger.value.yToRowIndex.get(y) ?? 0;
+  return props.stagger && rowIndex % 2 === 1 ? stagger.value.xStep / 2 : 0;
+}
+
+const renderedMarkers = computed(() =>
+  processedMarkers.value.map((marker, index) => {
+    const offsetX = rowOffset(marker.y);
+    const x = marker.x + offsetX;
+    const y = marker.y;
+    const r = marker.size ?? props.dotRadius;
+    const shouldPulse = props.pulse
+      ? marker.pulse !== false
+      : marker.pulse === true;
+    const pulseTo = r * 2.8;
+    return { marker: { ...marker, x, y }, index, x, y, r, shouldPulse, pulseTo };
+  }),
+);
+</script>
+
+<template>
+  <svg
+    :viewBox="`0 0 ${props.width} ${props.height}`"
+    :class="cn('text-gray-500 dark:text-gray-500', props.class)"
+    style="width: 100%; height: 100%"
+  >
+    <circle
+      v-for="(point, index) in points"
+      :key="`${point.x}-${point.y}-${index}`"
+      :cx="point.x + rowOffset(point.y)"
+      :cy="point.y"
+      :r="props.dotRadius"
+      :fill="props.dotColor"
+    />
+
+    <g
+      v-for="item in renderedMarkers"
+      :key="`${item.x}-${item.y}-${item.index}`"
+    >
+      <circle :cx="item.x" :cy="item.y" :r="item.r" :fill="props.markerColor" />
+
+      <g v-if="item.shouldPulse" pointer-events="none">
+        <circle
+          :cx="item.x"
+          :cy="item.y"
+          :r="item.r"
+          fill="none"
+          :stroke="props.markerColor"
+          :stroke-opacity="1"
+          :stroke-width="0.35"
+        >
+          <animate
+            attributeName="r"
+            :values="`${item.r};${item.pulseTo}`"
+            dur="1.4s"
+            repeatCount="indefinite"
+          />
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            dur="1.4s"
+            repeatCount="indefinite"
+          />
+        </circle>
+        <circle
+          :cx="item.x"
+          :cy="item.y"
+          :r="item.r"
+          fill="none"
+          :stroke="props.markerColor"
+          :stroke-opacity="0.9"
+          :stroke-width="0.3"
+        >
+          <animate
+            attributeName="r"
+            :values="`${item.r};${item.pulseTo}`"
+            dur="1.4s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+          <animate
+            attributeName="opacity"
+            values="0.9;0"
+            dur="1.4s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+        </circle>
+      </g>
+
+      <slot
+        name="marker"
+        :marker="item.marker"
+        :index="item.index"
+        :x="item.x"
+        :y="item.y"
+        :r="item.r"
+      />
+    </g>
+  </svg>
+</template>

--- a/docs/src/example/dotted-map/demo-2.vue
+++ b/docs/src/example/dotted-map/demo-2.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import DottedMap from "./dotted-map.vue";
+</script>
+
+<template>
+  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+    <DottedMap :dot-radius="0.1" />
+  </div>
+</template>

--- a/docs/src/example/dotted-map/demo-3.vue
+++ b/docs/src/example/dotted-map/demo-3.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import DottedMap from "./dotted-map.vue";
+import type { Marker } from "./dotted-map.vue";
+
+const markers: Marker[] = [
+  {
+    lat: 37.5665,
+    lng: 126.978,
+    size: 0.3,
+  },
+  {
+    lat: 40.7128,
+    lng: -74.006,
+    size: 0.3,
+    pulse: false,
+  },
+];
+</script>
+
+<template>
+  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+    <div
+      class="absolute inset-0 bg-radial from-transparent to-background to-200%"
+    />
+    <DottedMap :markers="markers" pulse />
+  </div>
+</template>

--- a/docs/src/example/dotted-map/demo.vue
+++ b/docs/src/example/dotted-map/demo.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import DottedMap from "./dotted-map.vue";
+import type { Marker } from "./dotted-map.vue";
+
+type MyMarker = Marker & {
+  overlay: {
+    countryCode: string;
+    label: string;
+  };
+};
+
+const markers: MyMarker[] = [
+  {
+    lat: 37.5665,
+    lng: 126.978,
+    size: 2.8,
+    overlay: { countryCode: "kr", label: "Seoul" },
+  },
+  {
+    lat: 40.7128,
+    lng: -74.006,
+    size: 2.8,
+    overlay: { countryCode: "us", label: "NYC" },
+  },
+];
+
+const id = "dotted-map-demo";
+</script>
+
+<template>
+  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+    <div
+      class="absolute inset-0 bg-radial from-transparent to-background to-200%"
+    />
+    <DottedMap :markers="markers">
+      <template #marker="{ marker, x, y, r, index }">
+        <g style="pointer-events: none">
+          <clipPath :id="`${id}-flag-clip-${index}`">
+            <circle :cx="x" :cy="y" :r="r * 0.75" />
+          </clipPath>
+
+          <image
+            :href="`https://flagcdn.com/w80/${marker.overlay.countryCode}.webp`"
+            :x="x - r * 0.75"
+            :y="y - r * 0.75"
+            :width="r * 0.75 * 2"
+            :height="r * 0.75 * 2"
+            preserveAspectRatio="xMidYMid slice"
+            :clip-path="`url(#${id}-flag-clip-${index})`"
+          />
+
+          <rect
+            :x="x + r + r * 0.6"
+            :y="y - (r * 1.5) / 2"
+            :width="
+              marker.overlay.label.length * (r * 0.9 * 0.62) +
+              r * 1.4
+            "
+            :height="r * 1.5"
+            :rx="(r * 1.5) / 2"
+            fill="rgba(0,0,0,0.55)"
+          />
+          <text
+            :x="x + r + r * 0.6 + r * 0.7"
+            :y="y + r * 0.9 * 0.35"
+            :font-size="r * 0.9"
+            fill="white"
+          >
+            {{ marker.overlay.label }}
+          </text>
+        </g>
+      </template>
+    </DottedMap>
+  </div>
+</template>

--- a/docs/src/example/dotted-map/dotted-map.vue
+++ b/docs/src/example/dotted-map/dotted-map.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { createMap } from "svg-dotted-map";
+import { cn } from "../../lib/utils";
+
+export interface Marker {
+  lat: number;
+  lng: number;
+  size?: number;
+  pulse?: boolean;
+  [key: string]: any;
+}
+
+/** Markers returned by addMarkers have lat/lng removed; x, y and other props remain. */
+export type MapMarker = Omit<Marker, "lat" | "lng"> & {
+  x: number;
+  y: number;
+};
+
+interface DottedMapProps {
+  class?: string;
+  width?: number;
+  height?: number;
+  mapSamples?: number;
+  markers?: Marker[];
+  dotColor?: string;
+  markerColor?: string;
+  dotRadius?: number;
+  stagger?: boolean;
+  pulse?: boolean;
+  [key: string]: any;
+}
+
+const props = withDefaults(defineProps<DottedMapProps>(), {
+  width: 150,
+  height: 75,
+  mapSamples: 5000,
+  markers: () => [],
+  dotColor: "currentColor",
+  markerColor: "#FF6900",
+  dotRadius: 0.2,
+  stagger: true,
+  pulse: false,
+});
+
+defineSlots<{
+  marker?: (props: {
+    marker: MapMarker;
+    index: number;
+    x: number;
+    y: number;
+    r: number;
+  }) => unknown;
+}>();
+
+const map = computed(() =>
+  createMap({
+    width: props.width,
+    height: props.height,
+    mapSamples: props.mapSamples,
+  }),
+);
+
+const points = computed(() => map.value.points);
+
+const processedMarkers = computed(
+  () => map.value.addMarkers(props.markers) as MapMarker[],
+);
+
+// Compute stagger helpers in a single, simple pass.
+const stagger = computed(() => {
+  const sorted = [...points.value].sort((a, b) => a.y - b.y || a.x - b.x);
+  const rowMap = new Map<number, number>();
+  let step = 0;
+  let prevY = Number.NaN;
+  let prevXInRow = Number.NaN;
+
+  for (const p of sorted) {
+    if (p.y !== prevY) {
+      // new row
+      prevY = p.y;
+      prevXInRow = Number.NaN;
+      if (!rowMap.has(p.y)) rowMap.set(p.y, rowMap.size);
+    }
+    if (!Number.isNaN(prevXInRow)) {
+      const delta = p.x - prevXInRow;
+      if (delta > 0) step = step === 0 ? delta : Math.min(step, delta);
+    }
+    prevXInRow = p.x;
+  }
+
+  return { xStep: step || 1, yToRowIndex: rowMap };
+});
+
+function rowOffset(y: number) {
+  const rowIndex = stagger.value.yToRowIndex.get(y) ?? 0;
+  return props.stagger && rowIndex % 2 === 1 ? stagger.value.xStep / 2 : 0;
+}
+
+const renderedMarkers = computed(() =>
+  processedMarkers.value.map((marker, index) => {
+    const offsetX = rowOffset(marker.y);
+    const x = marker.x + offsetX;
+    const y = marker.y;
+    const r = marker.size ?? props.dotRadius;
+    const shouldPulse = props.pulse
+      ? marker.pulse !== false
+      : marker.pulse === true;
+    const pulseTo = r * 2.8;
+    return { marker: { ...marker, x, y }, index, x, y, r, shouldPulse, pulseTo };
+  }),
+);
+</script>
+
+<template>
+  <svg
+    :viewBox="`0 0 ${props.width} ${props.height}`"
+    :class="cn('text-gray-500 dark:text-gray-500', props.class)"
+    style="width: 100%; height: 100%"
+  >
+    <circle
+      v-for="(point, index) in points"
+      :key="`${point.x}-${point.y}-${index}`"
+      :cx="point.x + rowOffset(point.y)"
+      :cy="point.y"
+      :r="props.dotRadius"
+      :fill="props.dotColor"
+    />
+
+    <g
+      v-for="item in renderedMarkers"
+      :key="`${item.x}-${item.y}-${item.index}`"
+    >
+      <circle :cx="item.x" :cy="item.y" :r="item.r" :fill="props.markerColor" />
+
+      <g v-if="item.shouldPulse" pointer-events="none">
+        <circle
+          :cx="item.x"
+          :cy="item.y"
+          :r="item.r"
+          fill="none"
+          :stroke="props.markerColor"
+          :stroke-opacity="1"
+          :stroke-width="0.35"
+        >
+          <animate
+            attributeName="r"
+            :values="`${item.r};${item.pulseTo}`"
+            dur="1.4s"
+            repeatCount="indefinite"
+          />
+          <animate
+            attributeName="opacity"
+            values="1;0"
+            dur="1.4s"
+            repeatCount="indefinite"
+          />
+        </circle>
+        <circle
+          :cx="item.x"
+          :cy="item.y"
+          :r="item.r"
+          fill="none"
+          :stroke="props.markerColor"
+          :stroke-opacity="0.9"
+          :stroke-width="0.3"
+        >
+          <animate
+            attributeName="r"
+            :values="`${item.r};${item.pulseTo}`"
+            dur="1.4s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+          <animate
+            attributeName="opacity"
+            values="0.9;0"
+            dur="1.4s"
+            begin="0.7s"
+            repeatCount="indefinite"
+          />
+        </circle>
+      </g>
+
+      <slot
+        name="marker"
+        :marker="item.marker"
+        :index="item.index"
+        :x="item.x"
+        :y="item.y"
+        :r="item.r"
+      />
+    </g>
+  </svg>
+</template>

--- a/docs/src/spark-ui-demos/dotted-map/dotted-map.vue
+++ b/docs/src/spark-ui-demos/dotted-map/dotted-map.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import DottedMap from "../../components/spark-ui/dotted-map/dotted-map.vue";
+import type { Marker } from "../../components/spark-ui/dotted-map/dotted-map.vue";
+
+type MyMarker = Marker & {
+  overlay: {
+    countryCode: string;
+    label: string;
+  };
+};
+
+const markers: MyMarker[] = [
+  {
+    lat: 37.5665,
+    lng: 126.978,
+    size: 2.8,
+    overlay: { countryCode: "kr", label: "Seoul" },
+  },
+  {
+    lat: 40.7128,
+    lng: -74.006,
+    size: 2.8,
+    overlay: { countryCode: "us", label: "NYC" },
+  },
+];
+
+const id = "dotted-map-demo";
+</script>
+
+<template>
+  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+    <div
+      class="absolute inset-0 bg-radial from-transparent to-background to-200%"
+    />
+    <DottedMap :markers="markers">
+      <template #marker="{ marker, x, y, r, index }">
+        <g style="pointer-events: none">
+          <clipPath :id="`${id}-flag-clip-${index}`">
+            <circle :cx="x" :cy="y" :r="r * 0.75" />
+          </clipPath>
+
+          <image
+            :href="`https://flagcdn.com/w80/${marker.overlay.countryCode}.webp`"
+            :x="x - r * 0.75"
+            :y="y - r * 0.75"
+            :width="r * 0.75 * 2"
+            :height="r * 0.75 * 2"
+            preserveAspectRatio="xMidYMid slice"
+            :clip-path="`url(#${id}-flag-clip-${index})`"
+          />
+
+          <rect
+            :x="x + r + r * 0.6"
+            :y="y - (r * 1.5) / 2"
+            :width="
+              marker.overlay.label.length * (r * 0.9 * 0.62) +
+              r * 1.4
+            "
+            :height="r * 1.5"
+            :rx="(r * 1.5) / 2"
+            fill="rgba(0,0,0,0.55)"
+          />
+          <text
+            :x="x + r + r * 0.6 + r * 0.7"
+            :y="y + r * 0.9 * 0.35"
+            :font-size="r * 0.9"
+            fill="white"
+          >
+            {{ marker.overlay.label }}
+          </text>
+        </g>
+      </template>
+    </DottedMap>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/dotted-map/pulse-marker.vue
+++ b/docs/src/spark-ui-demos/dotted-map/pulse-marker.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import DottedMap from "../../components/spark-ui/dotted-map/dotted-map.vue";
+import type { Marker } from "../../components/spark-ui/dotted-map/dotted-map.vue";
+
+const markers: Marker[] = [
+  {
+    lat: 37.5665,
+    lng: 126.978,
+    size: 0.3,
+  },
+  {
+    lat: 40.7128,
+    lng: -74.006,
+    size: 0.3,
+    pulse: false,
+  },
+];
+</script>
+
+<template>
+  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+    <div
+      class="absolute inset-0 bg-radial from-transparent to-background to-200%"
+    />
+    <DottedMap :markers="markers" pulse />
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/dotted-map/smaller-dots.vue
+++ b/docs/src/spark-ui-demos/dotted-map/smaller-dots.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import DottedMap from "../../components/spark-ui/dotted-map/dotted-map.vue";
+</script>
+
+<template>
+  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+    <DottedMap :dot-radius="0.1" />
+  </div>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       markdown-it:
         specifier: ^14.1.0
         version: 14.2.0
+      svg-dotted-map:
+        specifier: ^2.1.0
+        version: 2.1.0
       tailwind-merge:
         specifier: ^2.5.3
         version: 2.6.1
@@ -3711,6 +3714,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svg-dotted-map@2.1.0:
+    resolution: {integrity: sha512-4RnunTLPFMyQGnkeqL7BfFT+M/9disoFfDVZBq2eOfRrMgBQBmYbu09QcH/SAxez4JRmqM0UYSgo9u/cpkeykA==}
+    deprecated: This package has been renamed to piri. Please install that instead.
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -7478,6 +7485,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svg-dotted-map@2.1.0: {}
 
   symbol-tree@3.2.4: {}
 

--- a/tests/dotted-map/dotted-map.spec.ts
+++ b/tests/dotted-map/dotted-map.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import DottedMap from "../../docs/src/components/spark-ui/dotted-map/dotted-map.vue";
+
+const seoul = { lat: 37.5665, lng: 126.978, size: 2.8 };
+
+it("renders an svg with the default viewBox and dot points", () => {
+  const wrapper = mount(DottedMap);
+  const svg = wrapper.get("svg");
+  expect(svg.attributes("viewBox")).toBe("0 0 150 75");
+  expect(wrapper.findAll("circle").length).toBeGreaterThan(0);
+});
+
+it("applies a custom viewBox for width/height and the base dot color class", () => {
+  const wrapper = mount(DottedMap, { props: { width: 100, height: 50 } });
+  const svg = wrapper.get("svg");
+  expect(svg.attributes("viewBox")).toBe("0 0 100 50");
+  expect(svg.classes()).toContain("text-gray-500");
+});
+
+it("uses the provided dotRadius and dotColor for map dots", () => {
+  const wrapper = mount(DottedMap, {
+    props: { dotRadius: 0.5, dotColor: "red", mapSamples: 500 },
+  });
+  const circle = wrapper.get("circle");
+  expect(circle.attributes("r")).toBe("0.5");
+  expect(circle.attributes("fill")).toBe("red");
+});
+
+it("renders markers filled with markerColor", () => {
+  const wrapper = mount(DottedMap, {
+    props: { markers: [seoul], markerColor: "#00ff00" },
+  });
+  const markerCircle = wrapper
+    .findAll("circle")
+    .find((c) => c.attributes("fill") === "#00ff00");
+  expect(markerCircle).toBeTruthy();
+});
+
+it("does not render pulse animations by default", () => {
+  const wrapper = mount(DottedMap, { props: { markers: [seoul] } });
+  expect(wrapper.findAll("animate").length).toBe(0);
+});
+
+it("renders pulse animations when pulse is enabled", () => {
+  const wrapper = mount(DottedMap, {
+    props: { markers: [seoul], pulse: true },
+  });
+  expect(wrapper.findAll("animate").length).toBeGreaterThan(0);
+});
+
+it("opts a marker out of pulsing via marker.pulse === false", () => {
+  const wrapper = mount(DottedMap, {
+    props: { markers: [{ ...seoul, pulse: false }], pulse: true },
+  });
+  expect(wrapper.findAll("animate").length).toBe(0);
+});
+
+it("pulses only opted-in markers when pulse is off", () => {
+  const wrapper = mount(DottedMap, {
+    props: { markers: [{ ...seoul, pulse: true }] },
+  });
+  expect(wrapper.findAll("animate").length).toBeGreaterThan(0);
+});
+
+it("exposes marker slot props for custom overlays", () => {
+  const wrapper = mount(DottedMap, {
+    props: { markers: [seoul] },
+    slots: {
+      marker: `<template #marker="{ label }"><text class="overlay">x</text></template>`,
+    },
+  });
+  expect(wrapper.find(".overlay").exists()).toBe(true);
+});
+
+it("merges a custom class onto the svg", () => {
+  const wrapper = mount(DottedMap, { props: { class: "my-map" } });
+  expect(wrapper.get("svg").classes()).toContain("my-map");
+});


### PR DESCRIPTION
Ports Magic UI's **Dotted Map** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/dotted-map/dotted-map.vue` — dotted world map with markers; all upstream props preserved (`width`, `height`, `mapSamples`, `markers`, `dotColor`, `markerColor`, `dotRadius`, `stagger`, `pulse`, per-marker `size`/`pulse`) including the SVG `<animate>` pulse rings
- Upstream's `renderMarkerOverlay` render prop becomes an idiomatic `marker` scoped slot (`{ marker, index, x, y, r }`)
- Dependency: `svg-dotted-map` (same framework-agnostic package upstream uses) added to `docs/package.json` only; lockfile committed
- All 3 upstream demos (default, smaller dots, pulse markers) + copy-paste sources
- Docs page (installation incl. dependency step, usage, examples, props/slots tables); one-line sidebar entry
- 10 passing tests in `tests/dotted-map/`

## Verification
- `pnpm lint` ✅
- `vue-tsc` docs typecheck ✅ (`scripts/tsconfig.json` step fails on `dev` too — pre-existing)
- `pnpm dlx tsx scripts/validate-component.ts` ✅
- Tests ✅ (10 passed)