### PR TITLE
feat(flickering-grid): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,6 +19,7 @@ const newComponents = [
 	{ text: "Aurora Text", link: "/content/components/aurora.md" },
 	{ text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
+	{ text: "Flickering Grid", link: "/content/components/flickering-grid.md" },
 ];
 
 const components = [

--- a/docs/content/components/flickering-grid.md
+++ b/docs/content/components/flickering-grid.md
@@ -1,0 +1,228 @@
+# Flickering Grid
+
+A canvas-based flickering grid background, fully customizable with size, gap, color, opacity and flicker rate.
+
+<demo src="../../src/example/flickering-grid/demo.vue" srcCode="../../src/spark-ui-demos/flickering-grid/flickering-grid.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [flickering-grid.vue]
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { cn } from "@/lib/utils";
+
+interface FlickeringGridProps {
+  class?: string;
+  squareSize?: number;
+  gridGap?: number;
+  flickerChance?: number;
+  color?: string;
+  width?: number;
+  height?: number;
+  maxOpacity?: number;
+}
+
+const props = withDefaults(defineProps<FlickeringGridProps>(), {
+  squareSize: 4,
+  gridGap: 6,
+  flickerChance: 0.3,
+  color: "rgb(0, 0, 0)",
+  maxOpacity: 0.3,
+});
+
+const containerRef = ref<HTMLDivElement | null>(null);
+const canvasRef = ref<HTMLCanvasElement | null>(null);
+const canvasSize = ref({ width: 0, height: 0 });
+
+const memoizedColor = computed(() => {
+  const toRGBA = (color: string) => {
+    if (typeof window === "undefined") {
+      return "rgba(0, 0, 0,";
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = 1;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return "rgba(255, 0, 0,";
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = Array.from(ctx.getImageData(0, 0, 1, 1).data);
+    return `rgba(${r}, ${g}, ${b},`;
+  };
+  return toRGBA(props.color);
+});
+
+interface GridParams {
+  cols: number;
+  rows: number;
+  squares: Float32Array;
+  dpr: number;
+}
+
+let isInView = false;
+let animationFrameId: number | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let intersectionObserver: IntersectionObserver | null = null;
+let gridParams: GridParams | null = null;
+let lastTime = 0;
+
+const setupCanvas = (
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): GridParams => {
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  const cols = Math.ceil(width / (props.squareSize + props.gridGap));
+  const rows = Math.ceil(height / (props.squareSize + props.gridGap));
+
+  const squares = new Float32Array(cols * rows);
+  for (let i = 0; i < squares.length; i++) {
+    squares[i] = Math.random() * props.maxOpacity;
+  }
+
+  return { cols, rows, squares, dpr };
+};
+
+const updateSquares = (squares: Float32Array, deltaTime: number) => {
+  for (let i = 0; i < squares.length; i++) {
+    if (Math.random() < props.flickerChance * deltaTime) {
+      squares[i] = Math.random() * props.maxOpacity;
+    }
+  }
+};
+
+const drawGrid = (
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  cols: number,
+  rows: number,
+  squares: Float32Array,
+  dpr: number,
+) => {
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = "transparent";
+  ctx.fillRect(0, 0, width, height);
+
+  for (let i = 0; i < cols; i++) {
+    for (let j = 0; j < rows; j++) {
+      const opacity = squares[i * rows + j];
+      ctx.fillStyle = `${memoizedColor.value}${opacity})`;
+      ctx.fillRect(
+        i * (props.squareSize + props.gridGap) * dpr,
+        j * (props.squareSize + props.gridGap) * dpr,
+        props.squareSize * dpr,
+        props.squareSize * dpr,
+      );
+    }
+  }
+};
+
+onMounted(() => {
+  const canvas = canvasRef.value;
+  const container = containerRef.value;
+  const ctx = canvas?.getContext("2d") ?? null;
+
+  if (!canvas || !container || !ctx) return;
+
+  const updateCanvasSize = () => {
+    const newWidth = props.width || container.clientWidth;
+    const newHeight = props.height || container.clientHeight;
+    canvasSize.value = { width: newWidth, height: newHeight };
+    gridParams = setupCanvas(canvas, newWidth, newHeight);
+  };
+
+  updateCanvasSize();
+
+  const animate = (time: number) => {
+    if (!isInView || !gridParams) return;
+
+    const deltaTime = (time - lastTime) / 1000;
+    lastTime = time;
+
+    updateSquares(gridParams.squares, deltaTime);
+    drawGrid(
+      ctx,
+      canvas.width,
+      canvas.height,
+      gridParams.cols,
+      gridParams.rows,
+      gridParams.squares,
+      gridParams.dpr,
+    );
+    animationFrameId = requestAnimationFrame(animate);
+  };
+
+  resizeObserver = new ResizeObserver(() => {
+    updateCanvasSize();
+  });
+  resizeObserver.observe(container);
+
+  intersectionObserver = new IntersectionObserver(
+    ([entry]) => {
+      const wasInView = isInView;
+      isInView = entry.isIntersecting;
+      if (isInView && !wasInView) {
+        lastTime = performance.now();
+        animationFrameId = requestAnimationFrame(animate);
+      }
+    },
+    { threshold: 0 },
+  );
+  intersectionObserver.observe(canvas);
+});
+
+onUnmounted(() => {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+  }
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+  }
+  if (intersectionObserver) {
+    intersectionObserver.disconnect();
+  }
+});
+</script>
+
+<template>
+  <div ref="containerRef" :class="cn('h-full w-full', props.class)">
+    <canvas
+      ref="canvasRef"
+      class="pointer-events-none"
+      :style="{
+        width: `${canvasSize.width}px`,
+        height: `${canvasSize.height}px`,
+      }"
+    />
+  </div>
+</template>
+```
+
+:::
+
+## Examples
+
+### Rounded
+
+<demo src="../../src/example/flickering-grid/rounded-demo.vue" srcCode="../../src/spark-ui-demos/flickering-grid/rounded-demo.vue" />
+
+## Props
+
+| Prop            | Type     | Default          | Description                           |
+| --------------- | -------- | ---------------- | ------------------------------------- |
+| `class`         | `string` | `-`              | Additional CSS classes for the container |
+| `squareSize`    | `number` | `4`              | Size of each square in the grid       |
+| `gridGap`       | `number` | `6`              | Gap between squares in the grid       |
+| `flickerChance` | `number` | `0.3`            | Probability of a square flickering    |
+| `color`         | `string` | `"rgb(0, 0, 0)"` | Color of the squares                  |
+| `width`         | `number` | `-`              | Width of the canvas                   |
+| `height`        | `number` | `-`              | Height of the canvas                  |
+| `maxOpacity`    | `number` | `0.3`            | Maximum opacity of the squares        |

--- a/docs/src/components/spark-ui/flickering-grid/flickering-grid.vue
+++ b/docs/src/components/spark-ui/flickering-grid/flickering-grid.vue
@@ -1,0 +1,193 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface FlickeringGridProps {
+  class?: string;
+  squareSize?: number;
+  gridGap?: number;
+  flickerChance?: number;
+  color?: string;
+  width?: number;
+  height?: number;
+  maxOpacity?: number;
+}
+
+const props = withDefaults(defineProps<FlickeringGridProps>(), {
+  squareSize: 4,
+  gridGap: 6,
+  flickerChance: 0.3,
+  color: "rgb(0, 0, 0)",
+  maxOpacity: 0.3,
+});
+
+const containerRef = ref<HTMLDivElement | null>(null);
+const canvasRef = ref<HTMLCanvasElement | null>(null);
+const canvasSize = ref({ width: 0, height: 0 });
+
+const memoizedColor = computed(() => {
+  const toRGBA = (color: string) => {
+    if (typeof window === "undefined") {
+      return "rgba(0, 0, 0,";
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = 1;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return "rgba(255, 0, 0,";
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = Array.from(ctx.getImageData(0, 0, 1, 1).data);
+    return `rgba(${r}, ${g}, ${b},`;
+  };
+  return toRGBA(props.color);
+});
+
+interface GridParams {
+  cols: number;
+  rows: number;
+  squares: Float32Array;
+  dpr: number;
+}
+
+let isInView = false;
+let animationFrameId: number | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let intersectionObserver: IntersectionObserver | null = null;
+let gridParams: GridParams | null = null;
+let lastTime = 0;
+
+const setupCanvas = (
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): GridParams => {
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  const cols = Math.ceil(width / (props.squareSize + props.gridGap));
+  const rows = Math.ceil(height / (props.squareSize + props.gridGap));
+
+  const squares = new Float32Array(cols * rows);
+  for (let i = 0; i < squares.length; i++) {
+    squares[i] = Math.random() * props.maxOpacity;
+  }
+
+  return { cols, rows, squares, dpr };
+};
+
+const updateSquares = (squares: Float32Array, deltaTime: number) => {
+  for (let i = 0; i < squares.length; i++) {
+    if (Math.random() < props.flickerChance * deltaTime) {
+      squares[i] = Math.random() * props.maxOpacity;
+    }
+  }
+};
+
+const drawGrid = (
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  cols: number,
+  rows: number,
+  squares: Float32Array,
+  dpr: number,
+) => {
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = "transparent";
+  ctx.fillRect(0, 0, width, height);
+
+  for (let i = 0; i < cols; i++) {
+    for (let j = 0; j < rows; j++) {
+      const opacity = squares[i * rows + j];
+      ctx.fillStyle = `${memoizedColor.value}${opacity})`;
+      ctx.fillRect(
+        i * (props.squareSize + props.gridGap) * dpr,
+        j * (props.squareSize + props.gridGap) * dpr,
+        props.squareSize * dpr,
+        props.squareSize * dpr,
+      );
+    }
+  }
+};
+
+onMounted(() => {
+  const canvas = canvasRef.value;
+  const container = containerRef.value;
+  const ctx = canvas?.getContext("2d") ?? null;
+
+  if (!canvas || !container || !ctx) return;
+
+  const updateCanvasSize = () => {
+    const newWidth = props.width || container.clientWidth;
+    const newHeight = props.height || container.clientHeight;
+    canvasSize.value = { width: newWidth, height: newHeight };
+    gridParams = setupCanvas(canvas, newWidth, newHeight);
+  };
+
+  updateCanvasSize();
+
+  const animate = (time: number) => {
+    if (!isInView || !gridParams) return;
+
+    const deltaTime = (time - lastTime) / 1000;
+    lastTime = time;
+
+    updateSquares(gridParams.squares, deltaTime);
+    drawGrid(
+      ctx,
+      canvas.width,
+      canvas.height,
+      gridParams.cols,
+      gridParams.rows,
+      gridParams.squares,
+      gridParams.dpr,
+    );
+    animationFrameId = requestAnimationFrame(animate);
+  };
+
+  resizeObserver = new ResizeObserver(() => {
+    updateCanvasSize();
+  });
+  resizeObserver.observe(container);
+
+  intersectionObserver = new IntersectionObserver(
+    ([entry]) => {
+      const wasInView = isInView;
+      isInView = entry.isIntersecting;
+      if (isInView && !wasInView) {
+        lastTime = performance.now();
+        animationFrameId = requestAnimationFrame(animate);
+      }
+    },
+    { threshold: 0 },
+  );
+  intersectionObserver.observe(canvas);
+});
+
+onUnmounted(() => {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+  }
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+  }
+  if (intersectionObserver) {
+    intersectionObserver.disconnect();
+  }
+});
+</script>
+
+<template>
+  <div ref="containerRef" :class="cn('h-full w-full', props.class)">
+    <canvas
+      ref="canvasRef"
+      class="pointer-events-none"
+      :style="{
+        width: `${canvasSize.width}px`,
+        height: `${canvasSize.height}px`,
+      }"
+    />
+  </div>
+</template>

--- a/docs/src/example/flickering-grid/demo.vue
+++ b/docs/src/example/flickering-grid/demo.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "./flickering-grid.vue";
 
 <template>
   <div
-    class="relative h-[500px] w-[300px] overflow-hidden rounded-lg border bg-background md:w-[600px] lg:w-[850px]"
+    class="relative h-[500px] w-[300px] overflow-hidden rounded-lg border bg-background md:w-[500px]"
   >
     <FlickeringGrid
       class="absolute inset-0 z-0 size-full"

--- a/docs/src/example/flickering-grid/demo.vue
+++ b/docs/src/example/flickering-grid/demo.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import FlickeringGrid from "./flickering-grid.vue";
+</script>
+
+<template>
+  <div
+    class="relative h-[500px] w-full overflow-hidden rounded-lg border bg-background"
+  >
+    <FlickeringGrid
+      class="absolute inset-0 z-0 size-full"
+      :square-size="4"
+      :grid-gap="6"
+      color="#6B7280"
+      :max-opacity="0.5"
+      :flicker-chance="0.1"
+      :height="800"
+      :width="800"
+    />
+  </div>
+</template>

--- a/docs/src/example/flickering-grid/demo.vue
+++ b/docs/src/example/flickering-grid/demo.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "./flickering-grid.vue";
 
 <template>
   <div
-    class="relative h-[500px] w-full overflow-hidden rounded-lg border bg-background"
+    class="relative h-[500px] w-[300px] overflow-hidden rounded-lg border bg-background md:w-[600px] lg:w-[850px]"
   >
     <FlickeringGrid
       class="absolute inset-0 z-0 size-full"

--- a/docs/src/example/flickering-grid/flickering-grid.vue
+++ b/docs/src/example/flickering-grid/flickering-grid.vue
@@ -1,0 +1,193 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { cn } from "../../lib/utils";
+
+interface FlickeringGridProps {
+  class?: string;
+  squareSize?: number;
+  gridGap?: number;
+  flickerChance?: number;
+  color?: string;
+  width?: number;
+  height?: number;
+  maxOpacity?: number;
+}
+
+const props = withDefaults(defineProps<FlickeringGridProps>(), {
+  squareSize: 4,
+  gridGap: 6,
+  flickerChance: 0.3,
+  color: "rgb(0, 0, 0)",
+  maxOpacity: 0.3,
+});
+
+const containerRef = ref<HTMLDivElement | null>(null);
+const canvasRef = ref<HTMLCanvasElement | null>(null);
+const canvasSize = ref({ width: 0, height: 0 });
+
+const memoizedColor = computed(() => {
+  const toRGBA = (color: string) => {
+    if (typeof window === "undefined") {
+      return "rgba(0, 0, 0,";
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = 1;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return "rgba(255, 0, 0,";
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = Array.from(ctx.getImageData(0, 0, 1, 1).data);
+    return `rgba(${r}, ${g}, ${b},`;
+  };
+  return toRGBA(props.color);
+});
+
+interface GridParams {
+  cols: number;
+  rows: number;
+  squares: Float32Array;
+  dpr: number;
+}
+
+let isInView = false;
+let animationFrameId: number | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let intersectionObserver: IntersectionObserver | null = null;
+let gridParams: GridParams | null = null;
+let lastTime = 0;
+
+const setupCanvas = (
+  canvas: HTMLCanvasElement,
+  width: number,
+  height: number,
+): GridParams => {
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  const cols = Math.ceil(width / (props.squareSize + props.gridGap));
+  const rows = Math.ceil(height / (props.squareSize + props.gridGap));
+
+  const squares = new Float32Array(cols * rows);
+  for (let i = 0; i < squares.length; i++) {
+    squares[i] = Math.random() * props.maxOpacity;
+  }
+
+  return { cols, rows, squares, dpr };
+};
+
+const updateSquares = (squares: Float32Array, deltaTime: number) => {
+  for (let i = 0; i < squares.length; i++) {
+    if (Math.random() < props.flickerChance * deltaTime) {
+      squares[i] = Math.random() * props.maxOpacity;
+    }
+  }
+};
+
+const drawGrid = (
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  cols: number,
+  rows: number,
+  squares: Float32Array,
+  dpr: number,
+) => {
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = "transparent";
+  ctx.fillRect(0, 0, width, height);
+
+  for (let i = 0; i < cols; i++) {
+    for (let j = 0; j < rows; j++) {
+      const opacity = squares[i * rows + j];
+      ctx.fillStyle = `${memoizedColor.value}${opacity})`;
+      ctx.fillRect(
+        i * (props.squareSize + props.gridGap) * dpr,
+        j * (props.squareSize + props.gridGap) * dpr,
+        props.squareSize * dpr,
+        props.squareSize * dpr,
+      );
+    }
+  }
+};
+
+onMounted(() => {
+  const canvas = canvasRef.value;
+  const container = containerRef.value;
+  const ctx = canvas?.getContext("2d") ?? null;
+
+  if (!canvas || !container || !ctx) return;
+
+  const updateCanvasSize = () => {
+    const newWidth = props.width || container.clientWidth;
+    const newHeight = props.height || container.clientHeight;
+    canvasSize.value = { width: newWidth, height: newHeight };
+    gridParams = setupCanvas(canvas, newWidth, newHeight);
+  };
+
+  updateCanvasSize();
+
+  const animate = (time: number) => {
+    if (!isInView || !gridParams) return;
+
+    const deltaTime = (time - lastTime) / 1000;
+    lastTime = time;
+
+    updateSquares(gridParams.squares, deltaTime);
+    drawGrid(
+      ctx,
+      canvas.width,
+      canvas.height,
+      gridParams.cols,
+      gridParams.rows,
+      gridParams.squares,
+      gridParams.dpr,
+    );
+    animationFrameId = requestAnimationFrame(animate);
+  };
+
+  resizeObserver = new ResizeObserver(() => {
+    updateCanvasSize();
+  });
+  resizeObserver.observe(container);
+
+  intersectionObserver = new IntersectionObserver(
+    ([entry]) => {
+      const wasInView = isInView;
+      isInView = entry.isIntersecting;
+      if (isInView && !wasInView) {
+        lastTime = performance.now();
+        animationFrameId = requestAnimationFrame(animate);
+      }
+    },
+    { threshold: 0 },
+  );
+  intersectionObserver.observe(canvas);
+});
+
+onUnmounted(() => {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+  }
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+  }
+  if (intersectionObserver) {
+    intersectionObserver.disconnect();
+  }
+});
+</script>
+
+<template>
+  <div ref="containerRef" :class="cn('h-full w-full', props.class)">
+    <canvas
+      ref="canvasRef"
+      class="pointer-events-none"
+      :style="{
+        width: `${canvasSize.width}px`,
+        height: `${canvasSize.height}px`,
+      }"
+    />
+  </div>
+</template>

--- a/docs/src/example/flickering-grid/rounded-demo.vue
+++ b/docs/src/example/flickering-grid/rounded-demo.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "./flickering-grid.vue";
 
 <template>
   <div
-    class="relative size-[600px] max-w-full overflow-hidden rounded-lg border bg-background"
+    class="relative h-[500px] w-[300px] md:w-[500px] overflow-hidden rounded-lg border bg-background"
   >
     <FlickeringGrid
       class="relative inset-0 z-0 [mask-image:radial-gradient(450px_circle_at_center,white,transparent)]"

--- a/docs/src/example/flickering-grid/rounded-demo.vue
+++ b/docs/src/example/flickering-grid/rounded-demo.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "./flickering-grid.vue";
 
 <template>
   <div
-    class="relative size-[600px] w-full overflow-hidden rounded-lg border bg-background"
+    class="relative size-[600px] max-w-full overflow-hidden rounded-lg border bg-background"
   >
     <FlickeringGrid
       class="relative inset-0 z-0 [mask-image:radial-gradient(450px_circle_at_center,white,transparent)]"

--- a/docs/src/example/flickering-grid/rounded-demo.vue
+++ b/docs/src/example/flickering-grid/rounded-demo.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import FlickeringGrid from "./flickering-grid.vue";
+</script>
+
+<template>
+  <div
+    class="relative size-[600px] w-full overflow-hidden rounded-lg border bg-background"
+  >
+    <FlickeringGrid
+      class="relative inset-0 z-0 [mask-image:radial-gradient(450px_circle_at_center,white,transparent)]"
+      :square-size="4"
+      :grid-gap="6"
+      color="#60A5FA"
+      :max-opacity="0.5"
+      :flicker-chance="0.1"
+      :height="800"
+      :width="800"
+    />
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/flickering-grid/flickering-grid.vue
+++ b/docs/src/spark-ui-demos/flickering-grid/flickering-grid.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "../../components/spark-ui/flickering-grid/flickering
 
 <template>
   <div
-    class="relative h-[500px] w-[300px] overflow-hidden rounded-lg border bg-background md:w-[600px] lg:w-[850px]"
+    class="relative h-[500px] w-[300px] overflow-hidden rounded-lg border bg-background md:w-[500px]"
   >
     <FlickeringGrid
       class="absolute inset-0 z-0 size-full"

--- a/docs/src/spark-ui-demos/flickering-grid/flickering-grid.vue
+++ b/docs/src/spark-ui-demos/flickering-grid/flickering-grid.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "../../components/spark-ui/flickering-grid/flickering
 
 <template>
   <div
-    class="relative h-[500px] w-full overflow-hidden rounded-lg border bg-background"
+    class="relative h-[500px] w-[300px] overflow-hidden rounded-lg border bg-background md:w-[600px] lg:w-[850px]"
   >
     <FlickeringGrid
       class="absolute inset-0 z-0 size-full"

--- a/docs/src/spark-ui-demos/flickering-grid/flickering-grid.vue
+++ b/docs/src/spark-ui-demos/flickering-grid/flickering-grid.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import FlickeringGrid from "../../components/spark-ui/flickering-grid/flickering-grid.vue";
+</script>
+
+<template>
+  <div
+    class="relative h-[500px] w-full overflow-hidden rounded-lg border bg-background"
+  >
+    <FlickeringGrid
+      class="absolute inset-0 z-0 size-full"
+      :square-size="4"
+      :grid-gap="6"
+      color="#6B7280"
+      :max-opacity="0.5"
+      :flicker-chance="0.1"
+      :height="800"
+      :width="800"
+    />
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/flickering-grid/rounded-demo.vue
+++ b/docs/src/spark-ui-demos/flickering-grid/rounded-demo.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "../../components/spark-ui/flickering-grid/flickering
 
 <template>
   <div
-    class="relative size-[600px] w-full overflow-hidden rounded-lg border bg-background"
+    class="relative size-[600px] max-w-full overflow-hidden rounded-lg border bg-background"
   >
     <FlickeringGrid
       class="relative inset-0 z-0 [mask-image:radial-gradient(450px_circle_at_center,white,transparent)]"

--- a/docs/src/spark-ui-demos/flickering-grid/rounded-demo.vue
+++ b/docs/src/spark-ui-demos/flickering-grid/rounded-demo.vue
@@ -4,7 +4,7 @@ import FlickeringGrid from "../../components/spark-ui/flickering-grid/flickering
 
 <template>
   <div
-    class="relative size-[600px] max-w-full overflow-hidden rounded-lg border bg-background"
+    class="relative h-[500px] w-[300px] md:w-[500px] overflow-hidden rounded-lg border bg-background"
   >
     <FlickeringGrid
       class="relative inset-0 z-0 [mask-image:radial-gradient(450px_circle_at_center,white,transparent)]"

--- a/docs/src/spark-ui-demos/flickering-grid/rounded-demo.vue
+++ b/docs/src/spark-ui-demos/flickering-grid/rounded-demo.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import FlickeringGrid from "../../components/spark-ui/flickering-grid/flickering-grid.vue";
+</script>
+
+<template>
+  <div
+    class="relative size-[600px] w-full overflow-hidden rounded-lg border bg-background"
+  >
+    <FlickeringGrid
+      class="relative inset-0 z-0 [mask-image:radial-gradient(450px_circle_at_center,white,transparent)]"
+      :square-size="4"
+      :grid-gap="6"
+      color="#60A5FA"
+      :max-opacity="0.5"
+      :flicker-chance="0.1"
+      :height="800"
+      :width="800"
+    />
+  </div>
+</template>

--- a/tests/flickering-grid/flickering-grid.spec.ts
+++ b/tests/flickering-grid/flickering-grid.spec.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { beforeAll, expect, it, vi } from "vite-plus/test";
+import FlickeringGrid from "../../docs/src/components/spark-ui/flickering-grid/flickering-grid.vue";
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  vi.stubGlobal("requestAnimationFrame", () => 0);
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+  const canvasProto = (globalThis as unknown as { HTMLCanvasElement: { prototype: { getContext: unknown } } }).HTMLCanvasElement.prototype;
+  canvasProto.getContext = vi.fn(() => ({
+    fillStyle: "",
+    fillRect: () => {},
+    clearRect: () => {},
+    getImageData: () => ({ data: [0, 0, 0, 255] }),
+  }));
+});
+
+it("renders a container and a canvas", () => {
+  const wrapper = mount(FlickeringGrid);
+  expect(wrapper.find("canvas").exists()).toBe(true);
+});
+
+it("applies base container classes and merges a custom class", () => {
+  const wrapper = mount(FlickeringGrid, { props: { class: "my-grid" } });
+  const container = wrapper.get("div");
+  expect(container.classes()).toContain("h-full");
+  expect(container.classes()).toContain("w-full");
+  expect(container.classes()).toContain("my-grid");
+});
+
+it("marks the canvas as non-interactive", () => {
+  const wrapper = mount(FlickeringGrid);
+  expect(wrapper.get("canvas").classes()).toContain("pointer-events-none");
+});
+
+it("accepts flicker configuration props without error", () => {
+  const wrapper = mount(FlickeringGrid, {
+    props: {
+      squareSize: 8,
+      gridGap: 2,
+      flickerChance: 0.5,
+      color: "#60A5FA",
+      maxOpacity: 0.5,
+      width: 200,
+      height: 100,
+    },
+  });
+  expect(wrapper.find("canvas").exists()).toBe(true);
+});


### PR DESCRIPTION
Ports Magic UI's **Flickering Grid** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/flickering-grid/flickering-grid.vue` — canvas flicker animation with the exact upstream algorithm (`flickerChance * deltaTime`, `Float32Array` opacities), devicePixelRatio scaling, ResizeObserver + IntersectionObserver (animates only while in view), rAF loop; all props preserved (`squareSize`, `gridGap`, `flickerChance`, `color`, `width`, `height`, `maxOpacity`, `class`)
- SSR-safe: all canvas/observer work in `onMounted`, cleaned up on unmount
- Both upstream demos (default + rounded/mask) with copy-paste sources
- Docs page (installation, example, props table); one-line sidebar entry
- 4 passing tests in `tests/flickering-grid/`

## Verification
- `pnpm lint` ✅
- `vue-tsc` docs typecheck ✅ (`scripts/tsconfig.json` step fails on `dev` too — pre-existing)
- `pnpm dlx tsx scripts/validate-component.ts` ✅
- Tests ✅