### PR TITLE
feat(glare-hover): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,6 +19,7 @@ const newComponents = [
 	{ text: "Aurora Text", link: "/content/components/aurora.md" },
 	{ text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
+	{ text: "Glare Hover", link: "/content/components/glare-hover.md" },
 ];
 
 const components = [

--- a/docs/content/components/glare-hover.md
+++ b/docs/content/components/glare-hover.md
@@ -1,0 +1,141 @@
+# Glare Hover
+
+A diagonal light glare on hover using a `::before` gradient, CSS variables, and background-position animation—no extra global keyframes required.
+
+<demo src="../../src/example/glare-hover/demo.vue" srcCode="../../src/spark-ui-demos/glare-hover/glare-hover.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [glare-hover.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+interface GlareHoverProps {
+  class?: string;
+  width?: string;
+  height?: string;
+  background?: string;
+  color?: string;
+  opacity?: number;
+  angle?: number;
+  size?: number;
+  duration?: number;
+  playOnce?: boolean;
+}
+
+const props = withDefaults(defineProps<GlareHoverProps>(), {
+  background: "#000",
+  color: "#ffffff",
+  opacity: 0.5,
+  angle: -45,
+  size: 250,
+  duration: 650,
+  playOnce: false,
+});
+
+function parseHEX(color: string, opacity: number): string {
+  const hex = color.replace("#", "");
+  const parse = (h: string) => Number.parseInt(h, 16);
+  if (/^[0-9A-Fa-f]{6}$/.test(hex)) {
+    return `rgba(${parse(hex.slice(0, 2))},${parse(hex.slice(2, 4))},${parse(hex.slice(4, 6))},${opacity})`;
+  }
+  if (/^[0-9A-Fa-f]{3}$/.test(hex)) {
+    return `rgba(${parse(hex[0] + hex[0])},${parse(hex[1] + hex[1])},${parse(hex[2] + hex[2])},${opacity})`;
+  }
+  return color;
+}
+
+const rgba = computed(() => parseHEX(props.color, props.opacity));
+
+const cssVars = computed(() => ({
+  "--gh-angle": `${props.angle}deg`,
+  "--gh-duration": `${props.duration}ms`,
+  "--gh-size": `${props.size}%`,
+  "--gh-rgba": rgba.value,
+  background: props.background,
+  ...(props.width !== undefined ? { width: props.width } : {}),
+  ...(props.height !== undefined ? { height: props.height } : {}),
+}));
+
+const rootClass = computed(() =>
+  cn(
+    "relative grid w-fit h-fit cursor-pointer place-items-center overflow-hidden bg-transparent",
+    // BEFORE ELEMENT
+    "before:pointer-events-none before:absolute before:inset-0 before:z-10 before:bg-no-repeat before:content-['']",
+    // GRADIENT
+    "before:[background-image:linear-gradient(var(--gh-angle),transparent_60%,var(--gh-rgba)_70%,transparent,transparent_100%)]",
+    // SIZE + POSITION
+    "before:[background-size:var(--gh-size)_var(--gh-size),100%_100%]",
+    "before:[background-position:-100%_-100%,0_0]",
+    // TRANSITION
+    !props.playOnce &&
+      "before:transition-[background-position] before:duration-[var(--gh-duration)] before:ease-in-out",
+    props.playOnce &&
+      "before:transition-none hover:before:transition-[background-position] hover:before:duration-[var(--gh-duration)]",
+    // HOVER EFFECT
+    "hover:before:[background-position:100%_100%,0_0]",
+    props.class,
+  ),
+);
+</script>
+
+<template>
+  <div :class="rootClass" :style="cssVars">
+    <slot />
+  </div>
+</template>
+```
+
+:::
+
+## Usage
+
+The effect is implemented with a `::before` pseudo-element: a `linear-gradient` tile moves from one corner to the opposite on hover. Color is parsed from hex (`#rgb` or `#rrggbb`) into `rgba` for the glare band.
+
+```vue
+<script setup lang="ts">
+import GlareHover from "@/components/spark-ui/glare-hover/glare-hover.vue";
+</script>
+
+<template>
+  <GlareHover class="rounded-lg">
+    <div>Hover to see the glare sweep</div>
+  </GlareHover>
+</template>
+```
+
+## Examples
+
+### CTA
+
+<demo src="../../src/example/glare-hover/cta-demo.vue" srcCode="../../src/spark-ui-demos/glare-hover/cta-demo.vue" />
+
+### Alerts
+
+<demo src="../../src/example/glare-hover/alert-demo.vue" srcCode="../../src/spark-ui-demos/glare-hover/alert-demo.vue" />
+
+## Props
+
+| Prop       | Type    | Default     | Description                                                          |
+| ---------- | ------- | ----------- | ------------------------------------------------------------------- |
+| class      | string  |             | Classes on the root `div` (use `rounded-*`, `overflow-hidden`, etc.). |
+| background | string  | `"#000"`    | Root background color.                                              |
+| color      | string  | `"#ffffff"` | Glare highlight (hex `#rgb` / `#rrggbb`).                           |
+| opacity    | number  | `0.5`       | Alpha for the parsed glare color.                                   |
+| angle      | number  | `-45`       | Gradient angle in degrees (`--gh-angle`).                           |
+| size       | number  | `250`       | Glare tile size in `%` (`--gh-size`).                               |
+| duration   | number  | `650`       | Transition duration in ms (`--gh-duration`).                        |
+| playOnce   | boolean | `false`     | If `true`, animation runs on hover only (no transition until hover). |
+| width      | string  |             | Optional `width` on the root `style`.                              |
+| height     | string  |             | Optional `height` on the root `style`.                             |
+
+## Slots
+
+| Slot    | Description                    |
+| ------- | ----------------------------- |
+| default | Content inside the wrapper.   |

--- a/docs/src/components/spark-ui/glare-hover/glare-hover.vue
+++ b/docs/src/components/spark-ui/glare-hover/glare-hover.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface GlareHoverProps {
+  class?: string;
+  width?: string;
+  height?: string;
+  background?: string;
+  color?: string;
+  opacity?: number;
+  angle?: number;
+  size?: number;
+  duration?: number;
+  playOnce?: boolean;
+}
+
+const props = withDefaults(defineProps<GlareHoverProps>(), {
+  background: "#000",
+  color: "#ffffff",
+  opacity: 0.5,
+  angle: -45,
+  size: 250,
+  duration: 650,
+  playOnce: false,
+});
+
+function parseHEX(color: string, opacity: number): string {
+  const hex = color.replace("#", "");
+  const parse = (h: string) => Number.parseInt(h, 16);
+  if (/^[0-9A-Fa-f]{6}$/.test(hex)) {
+    return `rgba(${parse(hex.slice(0, 2))},${parse(hex.slice(2, 4))},${parse(hex.slice(4, 6))},${opacity})`;
+  }
+  if (/^[0-9A-Fa-f]{3}$/.test(hex)) {
+    return `rgba(${parse(hex[0] + hex[0])},${parse(hex[1] + hex[1])},${parse(hex[2] + hex[2])},${opacity})`;
+  }
+  return color;
+}
+
+const rgba = computed(() => parseHEX(props.color, props.opacity));
+
+const cssVars = computed(() => ({
+  "--gh-angle": `${props.angle}deg`,
+  "--gh-duration": `${props.duration}ms`,
+  "--gh-size": `${props.size}%`,
+  "--gh-rgba": rgba.value,
+  background: props.background,
+  ...(props.width !== undefined ? { width: props.width } : {}),
+  ...(props.height !== undefined ? { height: props.height } : {}),
+}));
+
+const rootClass = computed(() =>
+  cn(
+    "relative grid w-fit h-fit cursor-pointer place-items-center overflow-hidden bg-transparent",
+    // BEFORE ELEMENT
+    "before:pointer-events-none before:absolute before:inset-0 before:z-10 before:bg-no-repeat before:content-['']",
+    // GRADIENT
+    "before:[background-image:linear-gradient(var(--gh-angle),transparent_60%,var(--gh-rgba)_70%,transparent,transparent_100%)]",
+    // SIZE + POSITION
+    "before:[background-size:var(--gh-size)_var(--gh-size),100%_100%]",
+    "before:[background-position:-100%_-100%,0_0]",
+    // TRANSITION
+    !props.playOnce &&
+      "before:transition-[background-position] before:duration-[var(--gh-duration)] before:ease-in-out",
+    props.playOnce &&
+      "before:transition-none hover:before:transition-[background-position] hover:before:duration-[var(--gh-duration)]",
+    // HOVER EFFECT
+    "hover:before:[background-position:100%_100%,0_0]",
+    props.class,
+  ),
+);
+</script>
+
+<template>
+  <div :class="rootClass" :style="cssVars">
+    <slot />
+  </div>
+</template>

--- a/docs/src/example/glare-hover/alert-demo.vue
+++ b/docs/src/example/glare-hover/alert-demo.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import GlareHover from "./glare-hover.vue";
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <GlareHover class="rounded-lg" :duration="550" :opacity="0.25">
+      <div class="relative w-full rounded-lg border border-border bg-card p-4 text-card-foreground">
+        <svg
+          class="absolute left-4 top-4"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 16v-4M12 8h.01" />
+        </svg>
+        <div class="pl-10">
+          <h5 class="mb-1 font-medium leading-none tracking-tight">Action required</h5>
+          <div class="text-sm text-muted-foreground">
+            Your plan expires in 3 days. Renew to keep access.
+          </div>
+        </div>
+      </div>
+    </GlareHover>
+
+    <GlareHover class="w-full rounded-lg" color="#ff6070" :opacity="0.25" :duration="550">
+      <div
+        class="relative w-full rounded-lg border border-destructive/50 bg-background p-4 text-destructive"
+      >
+        <svg
+          class="absolute left-4 top-4"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+          <path d="M12 9v4M12 17h.01" />
+        </svg>
+        <div class="pl-10">
+          <h5 class="mb-1 font-medium leading-none tracking-tight">Payment declined</h5>
+          <div class="text-sm">Check your card details and try again.</div>
+        </div>
+      </div>
+    </GlareHover>
+
+    <GlareHover class="w-full rounded-lg" color="#60ff70" :opacity="0.25" :duration="550">
+      <div class="relative w-full rounded-lg border border-border bg-card p-4 text-card-foreground">
+        <svg
+          class="absolute left-4 top-4 stroke-emerald-500"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M21.801 10A10 10 0 1 1 17 3.335" />
+          <path d="m9 11 3 3L22 4" />
+        </svg>
+        <div class="pl-10">
+          <h5 class="mb-1 font-medium leading-none tracking-tight text-emerald-500">
+            Subscription confirmed
+          </h5>
+          <div class="text-sm text-emerald-500">
+            You have full Pro access until April 5, 2027.
+          </div>
+        </div>
+      </div>
+    </GlareHover>
+  </div>
+</template>

--- a/docs/src/example/glare-hover/cta-demo.vue
+++ b/docs/src/example/glare-hover/cta-demo.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import GlareHover from "./glare-hover.vue";
+</script>
+
+<template>
+  <GlareHover class="rounded-xl" color="#505050" :duration="700">
+    <div
+      class="w-full rounded-xl border border-border bg-card text-center text-card-foreground shadow-sm"
+    >
+      <div class="flex flex-col gap-1.5 p-6">
+        <p class="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          14-day free trial · No card required
+        </p>
+        <h3 class="text-2xl font-semibold leading-none tracking-tight">
+          Ready to get started?
+        </h3>
+        <p class="mx-auto max-w-sm text-sm text-muted-foreground">
+          Join 4,000+ teams already using our platform to ship faster.
+        </p>
+      </div>
+      <div class="flex items-center justify-center gap-2 p-6 pt-0">
+        <button
+          class="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Start free trial
+        </button>
+        <button
+          class="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          View demo
+        </button>
+      </div>
+    </div>
+  </GlareHover>
+</template>

--- a/docs/src/example/glare-hover/demo.vue
+++ b/docs/src/example/glare-hover/demo.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import GlareHover from "./glare-hover.vue";
+
+const features = ["Unlimited projects", "Team collaboration", "Advanced analytics"];
+</script>
+
+<template>
+  <GlareHover class="rounded-xl" :duration="600">
+    <div
+      class="w-[340px] rounded-xl border border-border bg-card text-card-foreground shadow-sm"
+    >
+      <div class="flex flex-col gap-1.5 p-6">
+        <div class="flex items-center justify-between">
+          <h3 class="text-lg font-semibold leading-none tracking-tight">Pro</h3>
+          <span
+            class="inline-flex items-center rounded-full bg-primary px-2.5 py-0.5 text-xs font-semibold text-primary-foreground"
+          >
+            Popular
+          </span>
+        </div>
+        <p class="text-sm text-muted-foreground">For teams that need more.</p>
+        <div class="flex items-baseline gap-1 pt-2">
+          <span class="text-4xl font-semibold tracking-tight">$49</span>
+          <span class="text-sm text-muted-foreground">/mo</span>
+        </div>
+      </div>
+      <div class="flex flex-col gap-2.5 p-6 pt-0">
+        <div v-for="f in features" :key="f" class="flex items-center gap-2 text-sm">
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+            <path
+              d="M12.5 3.5L6 10L2.5 6.5"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          {{ f }}
+        </div>
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+            <circle cx="7.5" cy="7.5" r="1.5" fill="currentColor" opacity="0.4" />
+          </svg>
+          SSO (coming soon)
+        </div>
+      </div>
+      <div class="flex items-center p-6 pt-0">
+        <button
+          class="inline-flex h-9 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Get started
+        </button>
+      </div>
+    </div>
+  </GlareHover>
+</template>

--- a/docs/src/example/glare-hover/glare-hover.vue
+++ b/docs/src/example/glare-hover/glare-hover.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "../../lib/utils";
+
+interface GlareHoverProps {
+  class?: string;
+  width?: string;
+  height?: string;
+  background?: string;
+  color?: string;
+  opacity?: number;
+  angle?: number;
+  size?: number;
+  duration?: number;
+  playOnce?: boolean;
+}
+
+const props = withDefaults(defineProps<GlareHoverProps>(), {
+  background: "#000",
+  color: "#ffffff",
+  opacity: 0.5,
+  angle: -45,
+  size: 250,
+  duration: 650,
+  playOnce: false,
+});
+
+function parseHEX(color: string, opacity: number): string {
+  const hex = color.replace("#", "");
+  const parse = (h: string) => Number.parseInt(h, 16);
+  if (/^[0-9A-Fa-f]{6}$/.test(hex)) {
+    return `rgba(${parse(hex.slice(0, 2))},${parse(hex.slice(2, 4))},${parse(hex.slice(4, 6))},${opacity})`;
+  }
+  if (/^[0-9A-Fa-f]{3}$/.test(hex)) {
+    return `rgba(${parse(hex[0] + hex[0])},${parse(hex[1] + hex[1])},${parse(hex[2] + hex[2])},${opacity})`;
+  }
+  return color;
+}
+
+const rgba = computed(() => parseHEX(props.color, props.opacity));
+
+const cssVars = computed(() => ({
+  "--gh-angle": `${props.angle}deg`,
+  "--gh-duration": `${props.duration}ms`,
+  "--gh-size": `${props.size}%`,
+  "--gh-rgba": rgba.value,
+  background: props.background,
+  ...(props.width !== undefined ? { width: props.width } : {}),
+  ...(props.height !== undefined ? { height: props.height } : {}),
+}));
+
+const rootClass = computed(() =>
+  cn(
+    "relative grid w-fit h-fit cursor-pointer place-items-center overflow-hidden bg-transparent",
+    "before:pointer-events-none before:absolute before:inset-0 before:z-10 before:bg-no-repeat before:content-['']",
+    "before:[background-image:linear-gradient(var(--gh-angle),transparent_60%,var(--gh-rgba)_70%,transparent,transparent_100%)]",
+    "before:[background-size:var(--gh-size)_var(--gh-size),100%_100%]",
+    "before:[background-position:-100%_-100%,0_0]",
+    !props.playOnce &&
+      "before:transition-[background-position] before:duration-[var(--gh-duration)] before:ease-in-out",
+    props.playOnce &&
+      "before:transition-none hover:before:transition-[background-position] hover:before:duration-[var(--gh-duration)]",
+    "hover:before:[background-position:100%_100%,0_0]",
+    props.class,
+  ),
+);
+</script>
+
+<template>
+  <div :class="rootClass" :style="cssVars">
+    <slot />
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/glare-hover/alert-demo.vue
+++ b/docs/src/spark-ui-demos/glare-hover/alert-demo.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import GlareHover from "../../components/spark-ui/glare-hover/glare-hover.vue";
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <GlareHover class="rounded-lg" :duration="550" :opacity="0.25">
+      <div class="relative w-full rounded-lg border border-border bg-card p-4 text-card-foreground">
+        <svg
+          class="absolute left-4 top-4"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 16v-4M12 8h.01" />
+        </svg>
+        <div class="pl-10">
+          <h5 class="mb-1 font-medium leading-none tracking-tight">Action required</h5>
+          <div class="text-sm text-muted-foreground">
+            Your plan expires in 3 days. Renew to keep access.
+          </div>
+        </div>
+      </div>
+    </GlareHover>
+
+    <GlareHover class="w-full rounded-lg" color="#ff6070" :opacity="0.25" :duration="550">
+      <div
+        class="relative w-full rounded-lg border border-destructive/50 bg-background p-4 text-destructive"
+      >
+        <svg
+          class="absolute left-4 top-4"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+          <path d="M12 9v4M12 17h.01" />
+        </svg>
+        <div class="pl-10">
+          <h5 class="mb-1 font-medium leading-none tracking-tight">Payment declined</h5>
+          <div class="text-sm">Check your card details and try again.</div>
+        </div>
+      </div>
+    </GlareHover>
+
+    <GlareHover class="w-full rounded-lg" color="#60ff70" :opacity="0.25" :duration="550">
+      <div class="relative w-full rounded-lg border border-border bg-card p-4 text-card-foreground">
+        <svg
+          class="absolute left-4 top-4 stroke-emerald-500"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M21.801 10A10 10 0 1 1 17 3.335" />
+          <path d="m9 11 3 3L22 4" />
+        </svg>
+        <div class="pl-10">
+          <h5 class="mb-1 font-medium leading-none tracking-tight text-emerald-500">
+            Subscription confirmed
+          </h5>
+          <div class="text-sm text-emerald-500">
+            You have full Pro access until April 5, 2027.
+          </div>
+        </div>
+      </div>
+    </GlareHover>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/glare-hover/cta-demo.vue
+++ b/docs/src/spark-ui-demos/glare-hover/cta-demo.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import GlareHover from "../../components/spark-ui/glare-hover/glare-hover.vue";
+</script>
+
+<template>
+  <GlareHover class="rounded-xl" color="#505050" :duration="700">
+    <div
+      class="w-full rounded-xl border border-border bg-card text-center text-card-foreground shadow-sm"
+    >
+      <div class="flex flex-col gap-1.5 p-6">
+        <p class="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          14-day free trial · No card required
+        </p>
+        <h3 class="text-2xl font-semibold leading-none tracking-tight">
+          Ready to get started?
+        </h3>
+        <p class="mx-auto max-w-sm text-sm text-muted-foreground">
+          Join 4,000+ teams already using our platform to ship faster.
+        </p>
+      </div>
+      <div class="flex items-center justify-center gap-2 p-6 pt-0">
+        <button
+          class="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Start free trial
+        </button>
+        <button
+          class="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-4 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          View demo
+        </button>
+      </div>
+    </div>
+  </GlareHover>
+</template>

--- a/docs/src/spark-ui-demos/glare-hover/glare-hover.vue
+++ b/docs/src/spark-ui-demos/glare-hover/glare-hover.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import GlareHover from "../../components/spark-ui/glare-hover/glare-hover.vue";
+
+const features = ["Unlimited projects", "Team collaboration", "Advanced analytics"];
+</script>
+
+<template>
+  <GlareHover class="rounded-xl" :duration="600">
+    <div
+      class="w-[340px] rounded-xl border border-border bg-card text-card-foreground shadow-sm"
+    >
+      <div class="flex flex-col gap-1.5 p-6">
+        <div class="flex items-center justify-between">
+          <h3 class="text-lg font-semibold leading-none tracking-tight">Pro</h3>
+          <span
+            class="inline-flex items-center rounded-full bg-primary px-2.5 py-0.5 text-xs font-semibold text-primary-foreground"
+          >
+            Popular
+          </span>
+        </div>
+        <p class="text-sm text-muted-foreground">For teams that need more.</p>
+        <div class="flex items-baseline gap-1 pt-2">
+          <span class="text-4xl font-semibold tracking-tight">$49</span>
+          <span class="text-sm text-muted-foreground">/mo</span>
+        </div>
+      </div>
+      <div class="flex flex-col gap-2.5 p-6 pt-0">
+        <div v-for="f in features" :key="f" class="flex items-center gap-2 text-sm">
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+            <path
+              d="M12.5 3.5L6 10L2.5 6.5"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          {{ f }}
+        </div>
+        <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+            <circle cx="7.5" cy="7.5" r="1.5" fill="currentColor" opacity="0.4" />
+          </svg>
+          SSO (coming soon)
+        </div>
+      </div>
+      <div class="flex items-center p-6 pt-0">
+        <button
+          class="inline-flex h-9 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Get started
+        </button>
+      </div>
+    </div>
+  </GlareHover>
+</template>

--- a/tests/glare-hover/glare-hover.spec.ts
+++ b/tests/glare-hover/glare-hover.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import GlareHover from "../../docs/src/components/spark-ui/glare-hover/glare-hover.vue";
+
+it("renders slot content", () => {
+  const wrapper = mount(GlareHover, { slots: { default: "Hello" } });
+  expect(wrapper.text()).toBe("Hello");
+});
+
+it("applies base classes and default css variables", () => {
+  const wrapper = mount(GlareHover);
+  const el = wrapper.get("div");
+  expect(el.classes()).toContain("relative");
+  expect(el.classes()).toContain("overflow-hidden");
+  const style = el.attributes("style") ?? "";
+  expect(style).toContain("--gh-angle: -45deg");
+  expect(style).toContain("--gh-duration: 650ms");
+  expect(style).toContain("--gh-size: 250%");
+  expect(style).toContain("background: rgb(0, 0, 0)");
+});
+
+it("parses a 6-digit hex color into rgba with opacity", () => {
+  const wrapper = mount(GlareHover, {
+    props: { color: "#a78bfa", opacity: 0.35 },
+  });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("--gh-rgba: rgba(167,139,250,0.35)");
+});
+
+it("parses a 3-digit hex color into rgba", () => {
+  const wrapper = mount(GlareHover, { props: { color: "#fff", opacity: 0.5 } });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("--gh-rgba: rgba(255,255,255,0.5)");
+});
+
+it("passes non-hex colors through untouched", () => {
+  const wrapper = mount(GlareHover, { props: { color: "red" } });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("--gh-rgba: red");
+});
+
+it("reflects custom angle, size and duration", () => {
+  const wrapper = mount(GlareHover, {
+    props: { angle: -30, size: 280, duration: 500 },
+  });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("--gh-angle: -30deg");
+  expect(style).toContain("--gh-size: 280%");
+  expect(style).toContain("--gh-duration: 500ms");
+});
+
+it("applies width and height when provided", () => {
+  const wrapper = mount(GlareHover, {
+    props: { width: "100%", height: "200px" },
+  });
+  const style = wrapper.get("div").attributes("style") ?? "";
+  expect(style).toContain("width: 100%");
+  expect(style).toContain("height: 200px");
+});
+
+it("uses transition classes by default and hover-only when playOnce", () => {
+  const normal = mount(GlareHover);
+  expect(normal.get("div").classes()).toContain(
+    "before:transition-[background-position]",
+  );
+
+  const once = mount(GlareHover, { props: { playOnce: true } });
+  const cls = once.get("div").classes();
+  expect(cls).toContain("before:transition-none");
+  expect(cls).toContain("hover:before:transition-[background-position]");
+});
+
+it("merges a custom class", () => {
+  const wrapper = mount(GlareHover, { props: { class: "rounded-xl" } });
+  expect(wrapper.get("div").classes()).toContain("rounded-xl");
+});


### PR DESCRIPTION
Ports Magic UI's **Glare Hover** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/glare-hover/glare-hover.vue` — diagonal light glare on hover via pure CSS transitions; all upstream props with identical defaults (`background`, `color`, `opacity`, `angle`, `size`, `duration`, `playOnce`, `width`, `height`, `class`); hex→rgba parsing preserved as a `computed`
- All upstream demos (default, CTA, alert) rebuilt without shadcn/Radix deps
- Docs page (installation, usage, examples, props/slots tables); sidebar entry
- 9 passing tests; verified rendering in the browser

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (9)
- Browser-rendered screenshot check ✅