### PR TITLE
feat(grid-pattern): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,7 @@ const newComponents = [
 	{ text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
 	{ text: "Dotted Map", link: "/content/components/dotted-map.md" },
+	{ text: "Grid Pattern", link: "/content/components/grid-pattern.md" },
 ];
 
 const components = [

--- a/docs/content/components/grid-pattern.md
+++ b/docs/content/components/grid-pattern.md
@@ -1,0 +1,104 @@
+# Grid Pattern
+
+A background grid pattern made with SVGs, fully customizable using Tailwind CSS.
+
+<demo src="../../src/example/grid-pattern/demo.vue" srcCode="../../src/spark-ui-demos/grid-pattern/grid-pattern.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [grid-pattern.vue]
+<script setup lang="ts">
+import { useId } from "vue";
+import { cn } from "@/lib/utils";
+
+interface GridPatternProps {
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  squares?: Array<[x: number, y: number]>;
+  strokeDasharray?: string;
+  class?: string;
+  [key: string]: any;
+}
+
+const props = withDefaults(defineProps<GridPatternProps>(), {
+  width: 40,
+  height: 40,
+  x: -1,
+  y: -1,
+  strokeDasharray: "0",
+});
+
+const id = `grid-pattern-${useId()}`;
+</script>
+
+<template>
+  <svg
+    aria-hidden="true"
+    :class="
+      cn(
+        'pointer-events-none absolute inset-0 h-full w-full fill-gray-400/30 stroke-gray-400/30',
+        props.class,
+      )
+    "
+  >
+    <defs>
+      <pattern
+        :id="id"
+        :width="props.width"
+        :height="props.height"
+        patternUnits="userSpaceOnUse"
+        :x="props.x"
+        :y="props.y"
+      >
+        <path
+          :d="`M.5 ${props.height}V.5H${props.width}`"
+          fill="none"
+          :stroke-dasharray="props.strokeDasharray"
+        />
+      </pattern>
+    </defs>
+    <rect width="100%" height="100%" stroke-width="0" :fill="`url(#${id})`" />
+    <svg v-if="props.squares" :x="props.x" :y="props.y" class="overflow-visible">
+      <rect
+        v-for="[squareX, squareY] in props.squares"
+        :key="`${squareX}-${squareY}`"
+        stroke-width="0"
+        :width="props.width - 1"
+        :height="props.height - 1"
+        :x="squareX * props.width + 1"
+        :y="squareY * props.height + 1"
+      />
+    </svg>
+  </svg>
+</template>
+```
+
+:::
+
+## Examples
+
+### Linear Gradient
+
+<demo src="../../src/example/grid-pattern/grid-pattern-linear-gradient.vue" srcCode="../../src/spark-ui-demos/grid-pattern/grid-pattern-linear-gradient.vue" />
+
+### Dashed Stroke
+
+<demo src="../../src/example/grid-pattern/grid-pattern-dashed.vue" srcCode="../../src/spark-ui-demos/grid-pattern/grid-pattern-dashed.vue" />
+
+## Props
+
+| Prop              | Type                          | Default | Description                                   |
+| ----------------- | ----------------------------- | ------- | --------------------------------------------- |
+| `width`           | `number`                      | `40`    | Width of the pattern                          |
+| `height`          | `number`                      | `40`    | Height of the pattern                         |
+| `x`               | `number`                      | `-1`    | X offset of the pattern                       |
+| `y`               | `number`                      | `-1`    | Y offset of the pattern                       |
+| `squares`         | `Array<[x: number, y: number]>` | `-`     | X Y coordinates of filled squares as 2D array |
+| `strokeDasharray` | `string`                      | `0`     | Stroke dash array for the pattern             |
+| `class`           | `string`                      | `-`     | Additional classes for the pattern            |

--- a/docs/src/components/spark-ui/grid-pattern/grid-pattern.vue
+++ b/docs/src/components/spark-ui/grid-pattern/grid-pattern.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { useId } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface GridPatternProps {
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  squares?: Array<[x: number, y: number]>;
+  strokeDasharray?: string;
+  class?: string;
+  [key: string]: any;
+}
+
+const props = withDefaults(defineProps<GridPatternProps>(), {
+  width: 40,
+  height: 40,
+  x: -1,
+  y: -1,
+  strokeDasharray: "0",
+});
+
+const id = `grid-pattern-${useId()}`;
+</script>
+
+<template>
+  <svg
+    aria-hidden="true"
+    :class="
+      cn(
+        'pointer-events-none absolute inset-0 h-full w-full fill-gray-400/30 stroke-gray-400/30',
+        props.class,
+      )
+    "
+  >
+    <defs>
+      <pattern
+        :id="id"
+        :width="props.width"
+        :height="props.height"
+        patternUnits="userSpaceOnUse"
+        :x="props.x"
+        :y="props.y"
+      >
+        <path
+          :d="`M.5 ${props.height}V.5H${props.width}`"
+          fill="none"
+          :stroke-dasharray="props.strokeDasharray"
+        />
+      </pattern>
+    </defs>
+    <rect width="100%" height="100%" stroke-width="0" :fill="`url(#${id})`" />
+    <svg v-if="props.squares" :x="props.x" :y="props.y" class="overflow-visible">
+      <rect
+        v-for="[squareX, squareY] in props.squares"
+        :key="`${squareX}-${squareY}`"
+        stroke-width="0"
+        :width="props.width - 1"
+        :height="props.height - 1"
+        :x="squareX * props.width + 1"
+        :y="squareY * props.height + 1"
+      />
+    </svg>
+  </svg>
+</template>

--- a/docs/src/example/grid-pattern/demo.vue
+++ b/docs/src/example/grid-pattern/demo.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+import GridPattern from "./grid-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex size-full flex-col items-center justify-center overflow-hidden rounded-lg border border-black/10 dark:border-white/10 h-[450px] w-[300px] md:w-[600px] lg:w-[850px]"
+  >
+    <GridPattern
+      :squares="[
+        [4, 4],
+        [5, 1],
+        [8, 2],
+        [5, 3],
+        [5, 5],
+        [10, 10],
+        [12, 15],
+        [15, 10],
+        [10, 15],
+      ]"
+      :class="
+        cn(
+          '[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]',
+          'inset-x-0 inset-y-[-30%] h-[200%] skew-y-12',
+        )
+      "
+    />
+  </div>
+</template>

--- a/docs/src/example/grid-pattern/grid-pattern-dashed.vue
+++ b/docs/src/example/grid-pattern/grid-pattern-dashed.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+import GridPattern from "./grid-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex size-full items-center justify-center overflow-hidden rounded-lg border border-black/10 dark:border-white/10 h-[450px] w-[300px] md:w-[600px] lg:w-[850px] p-20"
+  >
+    <GridPattern
+      :width="30"
+      :height="30"
+      :x="-1"
+      :y="-1"
+      stroke-dasharray="4 2"
+      :class="
+        cn('[mask-image:radial-gradient(300px_circle_at_center,white,transparent)]')
+      "
+    />
+  </div>
+</template>

--- a/docs/src/example/grid-pattern/grid-pattern-linear-gradient.vue
+++ b/docs/src/example/grid-pattern/grid-pattern-linear-gradient.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+import GridPattern from "./grid-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex size-full items-center justify-center overflow-hidden rounded-lg border border-black/10 dark:border-white/10 h-[450px] w-[300px] md:w-[600px] lg:w-[850px] p-20"
+  >
+    <GridPattern
+      :width="20"
+      :height="20"
+      :x="-1"
+      :y="-1"
+      :class="
+        cn('[mask-image:linear-gradient(to_bottom_right,white,transparent,transparent)]')
+      "
+    />
+  </div>
+</template>

--- a/docs/src/example/grid-pattern/grid-pattern.vue
+++ b/docs/src/example/grid-pattern/grid-pattern.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { useId } from "vue";
+import { cn } from "../../lib/utils";
+
+interface GridPatternProps {
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  squares?: Array<[x: number, y: number]>;
+  strokeDasharray?: string;
+  class?: string;
+  [key: string]: any;
+}
+
+const props = withDefaults(defineProps<GridPatternProps>(), {
+  width: 40,
+  height: 40,
+  x: -1,
+  y: -1,
+  strokeDasharray: "0",
+});
+
+const id = `grid-pattern-${useId()}`;
+</script>
+
+<template>
+  <svg
+    aria-hidden="true"
+    :class="
+      cn(
+        'pointer-events-none absolute inset-0 h-full w-full fill-gray-400/30 stroke-gray-400/30',
+        props.class,
+      )
+    "
+  >
+    <defs>
+      <pattern
+        :id="id"
+        :width="props.width"
+        :height="props.height"
+        patternUnits="userSpaceOnUse"
+        :x="props.x"
+        :y="props.y"
+      >
+        <path
+          :d="`M.5 ${props.height}V.5H${props.width}`"
+          fill="none"
+          :stroke-dasharray="props.strokeDasharray"
+        />
+      </pattern>
+    </defs>
+    <rect width="100%" height="100%" stroke-width="0" :fill="`url(#${id})`" />
+    <svg v-if="props.squares" :x="props.x" :y="props.y" class="overflow-visible">
+      <rect
+        v-for="[squareX, squareY] in props.squares"
+        :key="`${squareX}-${squareY}`"
+        stroke-width="0"
+        :width="props.width - 1"
+        :height="props.height - 1"
+        :x="squareX * props.width + 1"
+        :y="squareY * props.height + 1"
+      />
+    </svg>
+  </svg>
+</template>

--- a/docs/src/spark-ui-demos/grid-pattern/grid-pattern-dashed.vue
+++ b/docs/src/spark-ui-demos/grid-pattern/grid-pattern-dashed.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import GridPattern from "../../components/spark-ui/grid-pattern/grid-pattern.vue";
+import { cn } from "../../lib/utils";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex size-full items-center justify-center overflow-hidden rounded-lg border border-black/10 dark:border-white/10 h-[450px] w-[300px] md:w-[600px] lg:w-[850px] p-20"
+    >
+      <GridPattern
+        :width="30"
+        :height="30"
+        :x="-1"
+        :y="-1"
+        stroke-dasharray="4 2"
+        :class="
+          cn('[mask-image:radial-gradient(300px_circle_at_center,white,transparent)]')
+        "
+      />
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/grid-pattern/grid-pattern-linear-gradient.vue
+++ b/docs/src/spark-ui-demos/grid-pattern/grid-pattern-linear-gradient.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import GridPattern from "../../components/spark-ui/grid-pattern/grid-pattern.vue";
+import { cn } from "../../lib/utils";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex size-full items-center justify-center overflow-hidden rounded-lg border border-black/10 dark:border-white/10 h-[450px] w-[300px] md:w-[600px] lg:w-[850px] p-20"
+    >
+      <GridPattern
+        :width="20"
+        :height="20"
+        :x="-1"
+        :y="-1"
+        :class="
+          cn('[mask-image:linear-gradient(to_bottom_right,white,transparent,transparent)]')
+        "
+      />
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/grid-pattern/grid-pattern.vue
+++ b/docs/src/spark-ui-demos/grid-pattern/grid-pattern.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import GridPattern from "../../components/spark-ui/grid-pattern/grid-pattern.vue";
+import { cn } from "../../lib/utils";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex size-full flex-col items-center justify-center overflow-hidden rounded-lg border border-black/10 dark:border-white/10 h-[450px] w-[300px] md:w-[600px] lg:w-[850px]"
+    >
+      <GridPattern
+        :squares="[
+          [4, 4],
+          [5, 1],
+          [8, 2],
+          [5, 3],
+          [5, 5],
+          [10, 10],
+          [12, 15],
+          [15, 10],
+          [10, 15],
+        ]"
+        :class="
+          cn(
+            '[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]',
+            'inset-x-0 inset-y-[-30%] h-[200%] skew-y-12',
+          )
+        "
+      />
+    </div>
+  </div>
+</template>

--- a/tests/grid-pattern/grid-pattern.spec.ts
+++ b/tests/grid-pattern/grid-pattern.spec.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import GridPattern from "../../docs/src/components/spark-ui/grid-pattern/grid-pattern.vue";
+
+it("renders an accessible svg with base classes", () => {
+  const wrapper = mount(GridPattern);
+  const svg = wrapper.get("svg");
+  expect(svg.attributes("aria-hidden")).toBe("true");
+  expect(svg.classes()).toContain("pointer-events-none");
+  expect(svg.classes()).toContain("fill-gray-400/30");
+  expect(svg.classes()).toContain("stroke-gray-400/30");
+});
+
+it("applies default pattern dimensions and offsets", () => {
+  const wrapper = mount(GridPattern);
+  const pattern = wrapper.get("pattern");
+  expect(pattern.attributes("width")).toBe("40");
+  expect(pattern.attributes("height")).toBe("40");
+  expect(pattern.attributes("x")).toBe("-1");
+  expect(pattern.attributes("y")).toBe("-1");
+});
+
+it("builds the path from width/height", () => {
+  const wrapper = mount(GridPattern, { props: { width: 30, height: 20 } });
+  expect(wrapper.get("path").attributes("d")).toBe("M.5 20V.5H30");
+});
+
+it("passes strokeDasharray to the path", () => {
+  const wrapper = mount(GridPattern, { props: { strokeDasharray: "4 2" } });
+  expect(wrapper.get("path").attributes("stroke-dasharray")).toBe("4 2");
+});
+
+it("renders no squares by default", () => {
+  const wrapper = mount(GridPattern);
+  expect(wrapper.findAll("rect")).toHaveLength(1);
+});
+
+it("renders and positions filled squares", () => {
+  const wrapper = mount(GridPattern, {
+    props: { width: 40, height: 40, squares: [[4, 4], [5, 1]] },
+  });
+  const rects = wrapper.findAll("rect");
+  // 1 background rect + 2 square rects
+  expect(rects).toHaveLength(3);
+  const first = rects[1]!;
+  expect(first.attributes("width")).toBe("39");
+  expect(first.attributes("height")).toBe("39");
+  expect(first.attributes("x")).toBe("161");
+  expect(first.attributes("y")).toBe("161");
+});
+
+it("merges a custom class", () => {
+  const wrapper = mount(GridPattern, { props: { class: "my-mask" } });
+  expect(wrapper.get("svg").classes()).toContain("my-mask");
+});
+
+it("gives each instance a unique pattern id referenced by fill", () => {
+  const wrapper = mount(GridPattern);
+  const id = wrapper.get("pattern").attributes("id");
+  expect(id).toBeTruthy();
+  expect(wrapper.get("rect").attributes("fill")).toBe(`url(#${id})`);
+});


### PR DESCRIPTION
Ports Magic UI's **Grid Pattern** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/grid-pattern/grid-pattern.vue` — SVG grid with optional filled squares; all upstream props (`width`, `height`, `x`, `y`, `squares`, `strokeDasharray`, `class`); SSR-safe unique pattern id via `useId()`
- All 3 upstream demos (default skewed + radial mask, linear-gradient mask, dashed stroke) with copy-paste sources
- Docs page (installation, examples, props table); one-line sidebar entry
- 8 passing tests in `tests/grid-pattern/`

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (8)
- Browser screenshot check ✅ (grid, masks, and squares render contained in demo cards)