### PR TITLE
feat(hexagon-pattern): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,7 @@ const newComponents = [
 	{ text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
 	{ text: "Dotted Map", link: "/content/components/dotted-map.md" },
+	{ text: "Hexagon Pattern", link: "/content/components/hexagon-pattern.md" },
 ];
 
 const components = [

--- a/docs/content/components/hexagon-pattern.md
+++ b/docs/content/components/hexagon-pattern.md
@@ -1,0 +1,270 @@
+# Hexagon Pattern
+
+A background hexagon pattern made with SVGs, fully customizable using Tailwind CSS.
+
+<demo src="../../src/example/hexagon-pattern/demo.vue" srcCode="../../src/spark-ui-demos/hexagon-pattern/hexagon-pattern.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [hexagon-pattern.vue]
+<script setup lang="ts">
+import { computed, useId } from "vue";
+import { cn } from "@/lib/utils";
+
+type Direction = "horizontal" | "vertical";
+type HexPoint = readonly [number, number];
+
+interface HexagonPatternProps {
+  radius?: number;
+  gap?: number;
+  x?: number;
+  y?: number;
+  direction?: Direction;
+  strokeDasharray?: string;
+  hexagons?: Array<[number, number]>;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<HexagonPatternProps>(), {
+  radius: 40,
+  gap: 0,
+  x: -1,
+  y: -1,
+  direction: "horizontal",
+  strokeDasharray: "0",
+});
+
+const id = `hexagon-pattern-${useId()}`;
+
+function hexVertexList(cx: number, cy: number, r: number, direction: Direction): HexPoint[] {
+  const startAngle = direction === "horizontal" ? 0 : 30;
+  return Array.from({ length: 6 }, (_, i) => {
+    const angle = ((startAngle + i * 60) * Math.PI) / 180;
+    return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)] as const;
+  });
+}
+
+function hexPoints(cx: number, cy: number, r: number, direction: Direction): string {
+  return hexVertexList(cx, cy, r, direction)
+    .map(([px, py]) => `${px},${py}`)
+    .join(" ");
+}
+
+function edgeLexKey(a: HexPoint, b: HexPoint): string {
+  const [p, q] = a[0] < b[0] || (a[0] === b[0] && a[1] <= b[1]) ? [a, b] : [b, a];
+  return `${p[0].toFixed(6)},${p[1].toFixed(6)}|${q[0].toFixed(6)},${q[1].toFixed(6)}`;
+}
+
+function collectUniqueHexEdges(
+  centers: [number, number][],
+  r: number,
+  direction: Direction,
+): [HexPoint, HexPoint][] {
+  const seen = new Set<string>();
+  const edges: [HexPoint, HexPoint][] = [];
+  for (const [cx, cy] of centers) {
+    const verts = hexVertexList(cx, cy, r, direction);
+    for (let i = 0; i < 6; i++) {
+      const a = verts[i];
+      const b = verts[(i + 1) % 6];
+      const key = edgeLexKey(a, b);
+      if (!seen.has(key)) {
+        seen.add(key);
+        edges.push([a, b]);
+      }
+    }
+  }
+  return edges;
+}
+
+function isSolidStrokeDasharray(strokeDasharray: string): boolean {
+  const t = strokeDasharray.trim();
+  return t === "" || t === "none" || t === "0";
+}
+
+function getHexSpacing(r: number, direction: Direction, gap: number) {
+  const sqrt3 = Math.sqrt(3);
+  if (direction === "horizontal") {
+    const colStep = (3 * r) / 2 + (sqrt3 * gap) / 2;
+    const rowStep = sqrt3 * r + gap;
+    return { colStep, rowStep, tileW: colStep * 2, tileH: rowStep };
+  }
+  const colStep = sqrt3 * r + gap;
+  const rowStep = (3 * r) / 2 + (sqrt3 * gap) / 2;
+  return { colStep, rowStep, tileW: colStep, tileH: rowStep * 2 };
+}
+
+function getTileGeometry(r: number, direction: Direction, gap: number) {
+  const { colStep, rowStep, tileW, tileH } = getHexSpacing(r, direction, gap);
+  const canonical: [number, number][] =
+    direction === "horizontal"
+      ? [
+          [colStep / 2, rowStep / 2],
+          [(colStep * 3) / 2, rowStep],
+        ]
+      : [
+          [colStep / 2, rowStep / 2],
+          [colStep, (rowStep * 3) / 2],
+        ];
+
+  const centers: [number, number][] = [];
+  for (const [cx, cy] of canonical) {
+    centers.push([cx, cy]);
+    if (cy - r < 0) centers.push([cx, cy + tileH]);
+    if (cy + r > tileH) centers.push([cx, cy - tileH]);
+    if (cx - r < 0) centers.push([cx + tileW, cy]);
+    if (cx + r > tileW) centers.push([cx - tileW, cy]);
+    if (cy - r < 0 && cx - r < 0) centers.push([cx + tileW, cy + tileH]);
+    if (cy - r < 0 && cx + r > tileW) centers.push([cx - tileW, cy + tileH]);
+    if (cy + r > tileH && cx - r < 0) centers.push([cx + tileW, cy - tileH]);
+    if (cy + r > tileH && cx + r > tileW) centers.push([cx - tileW, cy - tileH]);
+  }
+
+  return { tileW, tileH, centers };
+}
+
+function hexCenter(
+  col: number,
+  row: number,
+  r: number,
+  direction: Direction,
+  gap: number,
+): [number, number] {
+  const { colStep, rowStep } = getHexSpacing(r, direction, gap);
+  if (direction === "horizontal") {
+    const cx = col * colStep + colStep / 2;
+    const cy = row * rowStep + rowStep / 2 + (col % 2 !== 0 ? rowStep / 2 : 0);
+    return [cx, cy];
+  }
+  const cx = col * colStep + colStep / 2 + (row % 2 !== 0 ? colStep / 2 : 0);
+  const cy = row * rowStep + rowStep / 2;
+  return [cx, cy];
+}
+
+const geometry = computed(() => getTileGeometry(props.radius, props.direction, props.gap));
+const solidStroke = computed(() => isSolidStrokeDasharray(props.strokeDasharray));
+const solidPolygons = computed(() =>
+  solidStroke.value
+    ? geometry.value.centers.map(([cx, cy]) => ({
+        key: `${cx}-${cy}`,
+        points: hexPoints(cx, cy, props.radius, props.direction),
+      }))
+    : [],
+);
+const dashedEdges = computed(() =>
+  solidStroke.value
+    ? []
+    : collectUniqueHexEdges(geometry.value.centers, props.radius, props.direction).map(([a, b]) => ({
+        key: edgeLexKey(a, b),
+        x1: a[0],
+        y1: a[1],
+        x2: b[0],
+        y2: b[1],
+      })),
+);
+const highlighted = computed(() =>
+  (props.hexagons ?? []).map(([col, row]) => {
+    const [cx, cy] = hexCenter(col, row, props.radius, props.direction, props.gap);
+    return {
+      key: `${col}-${row}`,
+      points: hexPoints(cx, cy, props.radius - 1, props.direction),
+    };
+  }),
+);
+</script>
+
+<template>
+  <svg
+    aria-hidden="true"
+    :class="
+      cn(
+        'pointer-events-none absolute inset-0 h-full w-full fill-gray-400/30 stroke-gray-400/30',
+        props.class,
+      )
+    "
+  >
+    <defs>
+      <pattern
+        :id="id"
+        :width="geometry.tileW"
+        :height="geometry.tileH"
+        patternUnits="userSpaceOnUse"
+        :x="props.x"
+        :y="props.y"
+      >
+        <template v-if="solidStroke">
+          <polygon
+            v-for="poly in solidPolygons"
+            :key="poly.key"
+            class="fill-none"
+            :points="poly.points"
+            :stroke-dasharray="props.strokeDasharray"
+          />
+        </template>
+        <template v-else>
+          <line
+            v-for="edge in dashedEdges"
+            :key="edge.key"
+            class="fill-none"
+            :x1="edge.x1"
+            :y1="edge.y1"
+            :x2="edge.x2"
+            :y2="edge.y2"
+            :stroke-dasharray="props.strokeDasharray"
+          />
+        </template>
+      </pattern>
+    </defs>
+
+    <rect width="100%" height="100%" :fill="`url(#${id})`" stroke="none" />
+
+    <svg
+      v-if="highlighted.length > 0"
+      aria-hidden="true"
+      class="overflow-visible"
+      :x="props.x"
+      :y="props.y"
+    >
+      <polygon
+        v-for="hex in highlighted"
+        :key="hex.key"
+        :points="hex.points"
+        stroke-width="0"
+      />
+    </svg>
+  </svg>
+</template>
+```
+
+:::
+
+## Examples
+
+### Linear Gradient
+
+<demo src="../../src/example/hexagon-pattern/hexagon-pattern-linear-gradient.vue" srcCode="../../src/spark-ui-demos/hexagon-pattern/hexagon-pattern-linear-gradient.vue" />
+
+### Dashed Stroke
+
+<demo src="../../src/example/hexagon-pattern/hexagon-pattern-dashed.vue" srcCode="../../src/spark-ui-demos/hexagon-pattern/hexagon-pattern-dashed.vue" />
+
+### Spacing
+
+<demo src="../../src/example/hexagon-pattern/hexagon-pattern-spacing.vue" srcCode="../../src/spark-ui-demos/hexagon-pattern/hexagon-pattern-spacing.vue" />
+
+## Props
+
+| Prop            | Type                         | Default        | Description                                                          |
+| --------------- | ---------------------------- | -------------- | ------------------------------------------------------------------- |
+| radius          | number                       | 40             | Radius from center to vertex for each hexagon                       |
+| gap             | number                       | 0              | Extra spacing between adjacent hexagons (pixels)                    |
+| x               | number                       | -1             | X offset of the pattern origin                                      |
+| y               | number                       | -1             | Y offset of the pattern origin                                      |
+| direction       | `"horizontal" \| "vertical"` | `"horizontal"` | `horizontal` — flat-top honeycomb; `vertical` — pointy-top honeycomb |
+| hexagons        | `Array<[col, row]>`          | -              | Grid coordinates of highlighted (filled) hexagons                   |
+| strokeDasharray | string                       | `"0"`          | SVG `stroke-dasharray` for the outline hexagons in the pattern      |
+| class           | string                       | -              | Additional classes on the root SVG (for example color utilities)    |

--- a/docs/src/components/spark-ui/hexagon-pattern/hexagon-pattern.vue
+++ b/docs/src/components/spark-ui/hexagon-pattern/hexagon-pattern.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import { computed, useId } from "vue";
+import { cn } from "../../../lib/utils";
+
+type Direction = "horizontal" | "vertical";
+type HexPoint = readonly [number, number];
+
+interface HexagonPatternProps {
+  radius?: number;
+  gap?: number;
+  x?: number;
+  y?: number;
+  direction?: Direction;
+  strokeDasharray?: string;
+  hexagons?: Array<[number, number]>;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<HexagonPatternProps>(), {
+  radius: 40,
+  gap: 0,
+  x: -1,
+  y: -1,
+  direction: "horizontal",
+  strokeDasharray: "0",
+});
+
+const id = `hexagon-pattern-${useId()}`;
+
+function hexVertexList(cx: number, cy: number, r: number, direction: Direction): HexPoint[] {
+  const startAngle = direction === "horizontal" ? 0 : 30;
+  return Array.from({ length: 6 }, (_, i) => {
+    const angle = ((startAngle + i * 60) * Math.PI) / 180;
+    return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)] as const;
+  });
+}
+
+function hexPoints(cx: number, cy: number, r: number, direction: Direction): string {
+  return hexVertexList(cx, cy, r, direction)
+    .map(([px, py]) => `${px},${py}`)
+    .join(" ");
+}
+
+function edgeLexKey(a: HexPoint, b: HexPoint): string {
+  const [p, q] = a[0] < b[0] || (a[0] === b[0] && a[1] <= b[1]) ? [a, b] : [b, a];
+  return `${p[0].toFixed(6)},${p[1].toFixed(6)}|${q[0].toFixed(6)},${q[1].toFixed(6)}`;
+}
+
+function collectUniqueHexEdges(
+  centers: [number, number][],
+  r: number,
+  direction: Direction,
+): [HexPoint, HexPoint][] {
+  const seen = new Set<string>();
+  const edges: [HexPoint, HexPoint][] = [];
+  for (const [cx, cy] of centers) {
+    const verts = hexVertexList(cx, cy, r, direction);
+    for (let i = 0; i < 6; i++) {
+      const a = verts[i];
+      const b = verts[(i + 1) % 6];
+      const key = edgeLexKey(a, b);
+      if (!seen.has(key)) {
+        seen.add(key);
+        edges.push([a, b]);
+      }
+    }
+  }
+  return edges;
+}
+
+function isSolidStrokeDasharray(strokeDasharray: string): boolean {
+  const t = strokeDasharray.trim();
+  return t === "" || t === "none" || t === "0";
+}
+
+function getHexSpacing(r: number, direction: Direction, gap: number) {
+  const sqrt3 = Math.sqrt(3);
+  if (direction === "horizontal") {
+    const colStep = (3 * r) / 2 + (sqrt3 * gap) / 2;
+    const rowStep = sqrt3 * r + gap;
+    return { colStep, rowStep, tileW: colStep * 2, tileH: rowStep };
+  }
+  const colStep = sqrt3 * r + gap;
+  const rowStep = (3 * r) / 2 + (sqrt3 * gap) / 2;
+  return { colStep, rowStep, tileW: colStep, tileH: rowStep * 2 };
+}
+
+function getTileGeometry(r: number, direction: Direction, gap: number) {
+  const { colStep, rowStep, tileW, tileH } = getHexSpacing(r, direction, gap);
+  const canonical: [number, number][] =
+    direction === "horizontal"
+      ? [
+          [colStep / 2, rowStep / 2],
+          [(colStep * 3) / 2, rowStep],
+        ]
+      : [
+          [colStep / 2, rowStep / 2],
+          [colStep, (rowStep * 3) / 2],
+        ];
+
+  const centers: [number, number][] = [];
+  for (const [cx, cy] of canonical) {
+    centers.push([cx, cy]);
+    if (cy - r < 0) centers.push([cx, cy + tileH]);
+    if (cy + r > tileH) centers.push([cx, cy - tileH]);
+    if (cx - r < 0) centers.push([cx + tileW, cy]);
+    if (cx + r > tileW) centers.push([cx - tileW, cy]);
+    if (cy - r < 0 && cx - r < 0) centers.push([cx + tileW, cy + tileH]);
+    if (cy - r < 0 && cx + r > tileW) centers.push([cx - tileW, cy + tileH]);
+    if (cy + r > tileH && cx - r < 0) centers.push([cx + tileW, cy - tileH]);
+    if (cy + r > tileH && cx + r > tileW) centers.push([cx - tileW, cy - tileH]);
+  }
+
+  return { tileW, tileH, centers };
+}
+
+function hexCenter(
+  col: number,
+  row: number,
+  r: number,
+  direction: Direction,
+  gap: number,
+): [number, number] {
+  const { colStep, rowStep } = getHexSpacing(r, direction, gap);
+  if (direction === "horizontal") {
+    const cx = col * colStep + colStep / 2;
+    const cy = row * rowStep + rowStep / 2 + (col % 2 !== 0 ? rowStep / 2 : 0);
+    return [cx, cy];
+  }
+  const cx = col * colStep + colStep / 2 + (row % 2 !== 0 ? colStep / 2 : 0);
+  const cy = row * rowStep + rowStep / 2;
+  return [cx, cy];
+}
+
+const geometry = computed(() => getTileGeometry(props.radius, props.direction, props.gap));
+const solidStroke = computed(() => isSolidStrokeDasharray(props.strokeDasharray));
+const solidPolygons = computed(() =>
+  solidStroke.value
+    ? geometry.value.centers.map(([cx, cy]) => ({
+        key: `${cx}-${cy}`,
+        points: hexPoints(cx, cy, props.radius, props.direction),
+      }))
+    : [],
+);
+const dashedEdges = computed(() =>
+  solidStroke.value
+    ? []
+    : collectUniqueHexEdges(geometry.value.centers, props.radius, props.direction).map(([a, b]) => ({
+        key: edgeLexKey(a, b),
+        x1: a[0],
+        y1: a[1],
+        x2: b[0],
+        y2: b[1],
+      })),
+);
+const highlighted = computed(() =>
+  (props.hexagons ?? []).map(([col, row]) => {
+    const [cx, cy] = hexCenter(col, row, props.radius, props.direction, props.gap);
+    return {
+      key: `${col}-${row}`,
+      points: hexPoints(cx, cy, props.radius - 1, props.direction),
+    };
+  }),
+);
+</script>
+
+<template>
+  <svg
+    aria-hidden="true"
+    :class="
+      cn(
+        'pointer-events-none absolute inset-0 h-full w-full fill-gray-400/30 stroke-gray-400/30',
+        props.class,
+      )
+    "
+  >
+    <defs>
+      <pattern
+        :id="id"
+        :width="geometry.tileW"
+        :height="geometry.tileH"
+        patternUnits="userSpaceOnUse"
+        :x="props.x"
+        :y="props.y"
+      >
+        <template v-if="solidStroke">
+          <polygon
+            v-for="poly in solidPolygons"
+            :key="poly.key"
+            class="fill-none"
+            :points="poly.points"
+            :stroke-dasharray="props.strokeDasharray"
+          />
+        </template>
+        <template v-else>
+          <line
+            v-for="edge in dashedEdges"
+            :key="edge.key"
+            class="fill-none"
+            :x1="edge.x1"
+            :y1="edge.y1"
+            :x2="edge.x2"
+            :y2="edge.y2"
+            :stroke-dasharray="props.strokeDasharray"
+          />
+        </template>
+      </pattern>
+    </defs>
+
+    <rect width="100%" height="100%" :fill="`url(#${id})`" stroke="none" />
+
+    <svg
+      v-if="highlighted.length > 0"
+      aria-hidden="true"
+      class="overflow-visible"
+      :x="props.x"
+      :y="props.y"
+    >
+      <polygon
+        v-for="hex in highlighted"
+        :key="hex.key"
+        :points="hex.points"
+        stroke-width="0"
+      />
+    </svg>
+  </svg>
+</template>

--- a/docs/src/example/hexagon-pattern/demo.vue
+++ b/docs/src/example/hexagon-pattern/demo.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+import HexagonPattern from "./hexagon-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg md:w-[600px] lg:w-[850px]"
+  >
+    <HexagonPattern
+      :hexagons="[
+        [1, 1],
+        [4, 4],
+        [2, 2],
+        [3, 4],
+        [5, 4],
+        [8, 2],
+        [6, 3],
+        [8, 5],
+        [10, 10],
+      ]"
+      :class="
+        cn(
+          '[mask-image:radial-gradient(420px_circle_at_center,white,transparent)]',
+          'inset-0 skew-y-6',
+        )
+      "
+    />
+  </div>
+</template>

--- a/docs/src/example/hexagon-pattern/demo.vue
+++ b/docs/src/example/hexagon-pattern/demo.vue
@@ -5,7 +5,7 @@ import HexagonPattern from "./hexagon-pattern.vue";
 
 <template>
   <div
-    class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg md:w-[600px] lg:w-[850px]"
+    class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg md:w-[500px]"
   >
     <HexagonPattern
       :hexagons="[

--- a/docs/src/example/hexagon-pattern/hexagon-pattern-dashed.vue
+++ b/docs/src/example/hexagon-pattern/hexagon-pattern-dashed.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import HexagonPattern from "./hexagon-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+  >
+    <HexagonPattern :radius="40" :x="-1" :y="-1" stroke-dasharray="4 2" />
+  </div>
+</template>

--- a/docs/src/example/hexagon-pattern/hexagon-pattern-dashed.vue
+++ b/docs/src/example/hexagon-pattern/hexagon-pattern-dashed.vue
@@ -4,7 +4,7 @@ import HexagonPattern from "./hexagon-pattern.vue";
 
 <template>
   <div
-    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[500px]"
   >
     <HexagonPattern :radius="40" :x="-1" :y="-1" stroke-dasharray="4 2" />
   </div>

--- a/docs/src/example/hexagon-pattern/hexagon-pattern-linear-gradient.vue
+++ b/docs/src/example/hexagon-pattern/hexagon-pattern-linear-gradient.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+import HexagonPattern from "./hexagon-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+  >
+    <HexagonPattern
+      :radius="40"
+      :x="-1"
+      :y="-1"
+      :class="
+        cn('[mask-image:linear-gradient(to_bottom_right,white,transparent,transparent)]')
+      "
+    />
+  </div>
+</template>

--- a/docs/src/example/hexagon-pattern/hexagon-pattern-linear-gradient.vue
+++ b/docs/src/example/hexagon-pattern/hexagon-pattern-linear-gradient.vue
@@ -5,7 +5,7 @@ import HexagonPattern from "./hexagon-pattern.vue";
 
 <template>
   <div
-    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[500px]"
   >
     <HexagonPattern
       :radius="40"

--- a/docs/src/example/hexagon-pattern/hexagon-pattern-spacing.vue
+++ b/docs/src/example/hexagon-pattern/hexagon-pattern-spacing.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import HexagonPattern from "./hexagon-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+  >
+    <HexagonPattern :gap="20" :radius="40" :x="-1" :y="-1" />
+  </div>
+</template>

--- a/docs/src/example/hexagon-pattern/hexagon-pattern-spacing.vue
+++ b/docs/src/example/hexagon-pattern/hexagon-pattern-spacing.vue
@@ -4,7 +4,7 @@ import HexagonPattern from "./hexagon-pattern.vue";
 
 <template>
   <div
-    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+    class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[500px]"
   >
     <HexagonPattern :gap="20" :radius="40" :x="-1" :y="-1" />
   </div>

--- a/docs/src/example/hexagon-pattern/hexagon-pattern.vue
+++ b/docs/src/example/hexagon-pattern/hexagon-pattern.vue
@@ -1,0 +1,227 @@
+<script setup lang="ts">
+import { computed, useId } from "vue";
+import { cn } from "../../lib/utils";
+
+type Direction = "horizontal" | "vertical";
+type HexPoint = readonly [number, number];
+
+interface HexagonPatternProps {
+  radius?: number;
+  gap?: number;
+  x?: number;
+  y?: number;
+  direction?: Direction;
+  strokeDasharray?: string;
+  hexagons?: Array<[number, number]>;
+  class?: string;
+}
+
+const props = withDefaults(defineProps<HexagonPatternProps>(), {
+  radius: 40,
+  gap: 0,
+  x: -1,
+  y: -1,
+  direction: "horizontal",
+  strokeDasharray: "0",
+});
+
+const id = `hexagon-pattern-${useId()}`;
+
+function hexVertexList(cx: number, cy: number, r: number, direction: Direction): HexPoint[] {
+  const startAngle = direction === "horizontal" ? 0 : 30;
+  return Array.from({ length: 6 }, (_, i) => {
+    const angle = ((startAngle + i * 60) * Math.PI) / 180;
+    return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)] as const;
+  });
+}
+
+function hexPoints(cx: number, cy: number, r: number, direction: Direction): string {
+  return hexVertexList(cx, cy, r, direction)
+    .map(([px, py]) => `${px},${py}`)
+    .join(" ");
+}
+
+function edgeLexKey(a: HexPoint, b: HexPoint): string {
+  const [p, q] = a[0] < b[0] || (a[0] === b[0] && a[1] <= b[1]) ? [a, b] : [b, a];
+  return `${p[0].toFixed(6)},${p[1].toFixed(6)}|${q[0].toFixed(6)},${q[1].toFixed(6)}`;
+}
+
+function collectUniqueHexEdges(
+  centers: [number, number][],
+  r: number,
+  direction: Direction,
+): [HexPoint, HexPoint][] {
+  const seen = new Set<string>();
+  const edges: [HexPoint, HexPoint][] = [];
+  for (const [cx, cy] of centers) {
+    const verts = hexVertexList(cx, cy, r, direction);
+    for (let i = 0; i < 6; i++) {
+      const a = verts[i];
+      const b = verts[(i + 1) % 6];
+      const key = edgeLexKey(a, b);
+      if (!seen.has(key)) {
+        seen.add(key);
+        edges.push([a, b]);
+      }
+    }
+  }
+  return edges;
+}
+
+function isSolidStrokeDasharray(strokeDasharray: string): boolean {
+  const t = strokeDasharray.trim();
+  return t === "" || t === "none" || t === "0";
+}
+
+function getHexSpacing(r: number, direction: Direction, gap: number) {
+  const sqrt3 = Math.sqrt(3);
+  if (direction === "horizontal") {
+    const colStep = (3 * r) / 2 + (sqrt3 * gap) / 2;
+    const rowStep = sqrt3 * r + gap;
+    return { colStep, rowStep, tileW: colStep * 2, tileH: rowStep };
+  }
+  const colStep = sqrt3 * r + gap;
+  const rowStep = (3 * r) / 2 + (sqrt3 * gap) / 2;
+  return { colStep, rowStep, tileW: colStep, tileH: rowStep * 2 };
+}
+
+function getTileGeometry(r: number, direction: Direction, gap: number) {
+  const { colStep, rowStep, tileW, tileH } = getHexSpacing(r, direction, gap);
+  const canonical: [number, number][] =
+    direction === "horizontal"
+      ? [
+          [colStep / 2, rowStep / 2],
+          [(colStep * 3) / 2, rowStep],
+        ]
+      : [
+          [colStep / 2, rowStep / 2],
+          [colStep, (rowStep * 3) / 2],
+        ];
+
+  const centers: [number, number][] = [];
+  for (const [cx, cy] of canonical) {
+    centers.push([cx, cy]);
+    if (cy - r < 0) centers.push([cx, cy + tileH]);
+    if (cy + r > tileH) centers.push([cx, cy - tileH]);
+    if (cx - r < 0) centers.push([cx + tileW, cy]);
+    if (cx + r > tileW) centers.push([cx - tileW, cy]);
+    if (cy - r < 0 && cx - r < 0) centers.push([cx + tileW, cy + tileH]);
+    if (cy - r < 0 && cx + r > tileW) centers.push([cx - tileW, cy + tileH]);
+    if (cy + r > tileH && cx - r < 0) centers.push([cx + tileW, cy - tileH]);
+    if (cy + r > tileH && cx + r > tileW) centers.push([cx - tileW, cy - tileH]);
+  }
+
+  return { tileW, tileH, centers };
+}
+
+function hexCenter(
+  col: number,
+  row: number,
+  r: number,
+  direction: Direction,
+  gap: number,
+): [number, number] {
+  const { colStep, rowStep } = getHexSpacing(r, direction, gap);
+  if (direction === "horizontal") {
+    const cx = col * colStep + colStep / 2;
+    const cy = row * rowStep + rowStep / 2 + (col % 2 !== 0 ? rowStep / 2 : 0);
+    return [cx, cy];
+  }
+  const cx = col * colStep + colStep / 2 + (row % 2 !== 0 ? colStep / 2 : 0);
+  const cy = row * rowStep + rowStep / 2;
+  return [cx, cy];
+}
+
+const geometry = computed(() => getTileGeometry(props.radius, props.direction, props.gap));
+const solidStroke = computed(() => isSolidStrokeDasharray(props.strokeDasharray));
+const solidPolygons = computed(() =>
+  solidStroke.value
+    ? geometry.value.centers.map(([cx, cy]) => ({
+        key: `${cx}-${cy}`,
+        points: hexPoints(cx, cy, props.radius, props.direction),
+      }))
+    : [],
+);
+const dashedEdges = computed(() =>
+  solidStroke.value
+    ? []
+    : collectUniqueHexEdges(geometry.value.centers, props.radius, props.direction).map(([a, b]) => ({
+        key: edgeLexKey(a, b),
+        x1: a[0],
+        y1: a[1],
+        x2: b[0],
+        y2: b[1],
+      })),
+);
+const highlighted = computed(() =>
+  (props.hexagons ?? []).map(([col, row]) => {
+    const [cx, cy] = hexCenter(col, row, props.radius, props.direction, props.gap);
+    return {
+      key: `${col}-${row}`,
+      points: hexPoints(cx, cy, props.radius - 1, props.direction),
+    };
+  }),
+);
+</script>
+
+<template>
+  <svg
+    aria-hidden="true"
+    :class="
+      cn(
+        'pointer-events-none absolute inset-0 h-full w-full fill-gray-400/30 stroke-gray-400/30',
+        props.class,
+      )
+    "
+  >
+    <defs>
+      <pattern
+        :id="id"
+        :width="geometry.tileW"
+        :height="geometry.tileH"
+        patternUnits="userSpaceOnUse"
+        :x="props.x"
+        :y="props.y"
+      >
+        <template v-if="solidStroke">
+          <polygon
+            v-for="poly in solidPolygons"
+            :key="poly.key"
+            class="fill-none"
+            :points="poly.points"
+            :stroke-dasharray="props.strokeDasharray"
+          />
+        </template>
+        <template v-else>
+          <line
+            v-for="edge in dashedEdges"
+            :key="edge.key"
+            class="fill-none"
+            :x1="edge.x1"
+            :y1="edge.y1"
+            :x2="edge.x2"
+            :y2="edge.y2"
+            :stroke-dasharray="props.strokeDasharray"
+          />
+        </template>
+      </pattern>
+    </defs>
+
+    <rect width="100%" height="100%" :fill="`url(#${id})`" stroke="none" />
+
+    <svg
+      v-if="highlighted.length > 0"
+      aria-hidden="true"
+      class="overflow-visible"
+      :x="props.x"
+      :y="props.y"
+    >
+      <polygon
+        v-for="hex in highlighted"
+        :key="hex.key"
+        :points="hex.points"
+        stroke-width="0"
+      />
+    </svg>
+  </svg>
+</template>

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-dashed.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-dashed.vue
@@ -5,7 +5,7 @@ import HexagonPattern from "../../components/spark-ui/hexagon-pattern/hexagon-pa
 <template>
   <div class="grid place-items-center w-full min-h-screen">
     <div
-      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[500px]"
     >
       <HexagonPattern :radius="40" :x="-1" :y="-1" stroke-dasharray="4 2" />
     </div>

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-dashed.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-dashed.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import HexagonPattern from "../../components/spark-ui/hexagon-pattern/hexagon-pattern.vue";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+    >
+      <HexagonPattern :radius="40" :x="-1" :y="-1" stroke-dasharray="4 2" />
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-linear-gradient.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-linear-gradient.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import HexagonPattern from "../../components/spark-ui/hexagon-pattern/hexagon-pattern.vue";
+import { cn } from "../../lib/utils";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+    >
+      <HexagonPattern
+        :radius="40"
+        :x="-1"
+        :y="-1"
+        :class="
+          cn('[mask-image:linear-gradient(to_bottom_right,white,transparent,transparent)]')
+        "
+      />
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-linear-gradient.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-linear-gradient.vue
@@ -6,7 +6,7 @@ import { cn } from "../../lib/utils";
 <template>
   <div class="grid place-items-center w-full min-h-screen">
     <div
-      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[500px]"
     >
       <HexagonPattern
         :radius="40"

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-spacing.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-spacing.vue
@@ -5,7 +5,7 @@ import HexagonPattern from "../../components/spark-ui/hexagon-pattern/hexagon-pa
 <template>
   <div class="grid place-items-center w-full min-h-screen">
     <div
-      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[500px]"
     >
       <HexagonPattern :gap="20" :radius="40" :x="-1" :y="-1" />
     </div>

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-spacing.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern-spacing.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import HexagonPattern from "../../components/spark-ui/hexagon-pattern/hexagon-pattern.vue";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex h-[450px] w-[300px] items-center justify-center overflow-hidden rounded-lg p-20 md:w-[600px] lg:w-[850px]"
+    >
+      <HexagonPattern :gap="20" :radius="40" :x="-1" :y="-1" />
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import HexagonPattern from "../../components/spark-ui/hexagon-pattern/hexagon-pattern.vue";
+import { cn } from "../../lib/utils";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg md:w-[600px] lg:w-[850px]"
+    >
+      <HexagonPattern
+        :hexagons="[
+          [1, 1],
+          [4, 4],
+          [2, 2],
+          [3, 4],
+          [5, 4],
+          [8, 2],
+          [6, 3],
+          [8, 5],
+          [10, 10],
+        ]"
+        :class="
+          cn(
+            '[mask-image:radial-gradient(420px_circle_at_center,white,transparent)]',
+            'inset-0 skew-y-6',
+          )
+        "
+      />
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern.vue
+++ b/docs/src/spark-ui-demos/hexagon-pattern/hexagon-pattern.vue
@@ -6,7 +6,7 @@ import { cn } from "../../lib/utils";
 <template>
   <div class="grid place-items-center w-full min-h-screen">
     <div
-      class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg md:w-[600px] lg:w-[850px]"
+      class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg md:w-[500px]"
     >
       <HexagonPattern
         :hexagons="[

--- a/tests/hexagon-pattern/hexagon-pattern.spec.ts
+++ b/tests/hexagon-pattern/hexagon-pattern.spec.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import HexagonPattern from "../../docs/src/components/spark-ui/hexagon-pattern/hexagon-pattern.vue";
+
+it("renders an svg with a userSpaceOnUse pattern", () => {
+  const wrapper = mount(HexagonPattern);
+  const svg = wrapper.get("svg");
+  expect(svg.attributes("aria-hidden")).toBe("true");
+  const pattern = wrapper.get("pattern");
+  expect(pattern.attributes("patternUnits")).toBe("userSpaceOnUse");
+});
+
+it("applies base pattern styling and merges a custom class", () => {
+  const wrapper = mount(HexagonPattern, { props: { class: "custom-mask" } });
+  const classes = wrapper.get("svg").classes();
+  expect(classes).toContain("absolute");
+  expect(classes).toContain("fill-gray-400/30");
+  expect(classes).toContain("stroke-gray-400/30");
+  expect(classes).toContain("custom-mask");
+});
+
+it("renders solid polygons by default (solid stroke)", () => {
+  const wrapper = mount(HexagonPattern);
+  expect(wrapper.findAll("pattern polygon").length).toBeGreaterThan(0);
+  expect(wrapper.findAll("pattern line").length).toBe(0);
+});
+
+it("renders dashed lines when strokeDasharray is not solid", () => {
+  const wrapper = mount(HexagonPattern, { props: { strokeDasharray: "4 2" } });
+  const lines = wrapper.findAll("pattern line");
+  expect(lines.length).toBeGreaterThan(0);
+  expect(lines[0]?.attributes("stroke-dasharray")).toBe("4 2");
+  expect(wrapper.findAll("pattern polygon").length).toBe(0);
+});
+
+it("renders highlighted hexagons for provided coordinates", () => {
+  const wrapper = mount(HexagonPattern, {
+    props: { hexagons: [[1, 1], [2, 2]] },
+  });
+  // inner svg holds the highlighted polygons (outside the pattern defs)
+  const highlighted = wrapper.findAll("svg svg polygon");
+  expect(highlighted.length).toBe(2);
+});
+
+it("applies x and y offset to the pattern origin", () => {
+  const wrapper = mount(HexagonPattern, { props: { x: -5, y: 3 } });
+  const pattern = wrapper.get("pattern");
+  expect(pattern.attributes("x")).toBe("-5");
+  expect(pattern.attributes("y")).toBe("3");
+});
+
+it("changes tile geometry between horizontal and vertical directions", () => {
+  const h = mount(HexagonPattern, { props: { direction: "horizontal" } });
+  const v = mount(HexagonPattern, { props: { direction: "vertical" } });
+  const hw = h.get("pattern").attributes("width");
+  const vw = v.get("pattern").attributes("width");
+  expect(hw).not.toBe(vw);
+});


### PR DESCRIPTION
Ports Magic UI's **Hexagon Pattern** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/hexagon-pattern/hexagon-pattern.vue` — full honeycomb geometry port (vertex/edge computation, unique-edge dedup for dashed strokes, tile wrapping, highlighted-hex centering); all props preserved (`radius`, `gap`, `x`, `y`, `direction`, `strokeDasharray`, `hexagons`, `class`)
- All 4 upstream demos (default + radial mask, linear gradient, dashed, spacing) with copy-paste sources, sized to fit the docs demo card
- Docs page (installation, examples, props table); one-line sidebar entry
- 7 passing tests in `tests/hexagon-pattern/`

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (7)
- Browser check ✅ — all four variants render contained (DOM-measured 500×450 wrappers inside the demo cards)