### PR TITLE
feat(highlighter): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,7 @@ const newComponents = [
 	{ text: "Resizable Navbar", link: "/content/components/resizable-navbar.md" },
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
 	{ text: "Dotted Map", link: "/content/components/dotted-map.md" },
+	{ text: "Highlighter", link: "/content/components/highlighter.md" },
 ];
 
 const components = [

--- a/docs/content/components/highlighter.md
+++ b/docs/content/components/highlighter.md
@@ -1,0 +1,212 @@
+# Highlighter
+
+A text highlighter that mimics the effect of a human-drawn marker stroke.
+
+<demo src="../../src/example/highlighter/demo.vue" srcCode="../../src/spark-ui-demos/highlighter/highlighter.vue" />
+
+## Installation
+
+Install the following dependency:
+
+::: code-group
+
+```bash [npm]
+npm install rough-notation
+```
+
+```bash [pnpm]
+pnpm add rough-notation
+```
+
+```bash [yarn]
+yarn add rough-notation
+```
+
+```bash [bun]
+bun add rough-notation
+```
+
+:::
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [highlighter.vue]
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, ref, watch } from "vue";
+import { annotate } from "rough-notation";
+import type { RoughAnnotation } from "rough-notation/lib/model";
+import { cn } from "@/lib/utils";
+
+type AnnotationAction =
+  | "highlight"
+  | "underline"
+  | "box"
+  | "circle"
+  | "strike-through"
+  | "crossed-off"
+  | "bracket";
+
+interface HighlighterProps {
+  class?: string;
+  action?: AnnotationAction;
+  color?: string;
+  strokeWidth?: number;
+  animationDuration?: number;
+  iterations?: number;
+  padding?: number;
+  multiline?: boolean;
+  isView?: boolean;
+}
+
+const props = withDefaults(defineProps<HighlighterProps>(), {
+  action: "highlight",
+  color: "#ffd1dc",
+  strokeWidth: 1.5,
+  animationDuration: 600,
+  iterations: 2,
+  padding: 2,
+  multiline: true,
+  isView: false,
+});
+
+const elementRef = ref<HTMLSpanElement | null>(null);
+const shouldShow = ref(false);
+
+let annotation: RoughAnnotation | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let intersectionObserver: IntersectionObserver | null = null;
+
+function clearAnnotation() {
+  annotation?.remove();
+  annotation = null;
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+}
+
+function draw() {
+  const element = elementRef.value;
+  if (!shouldShow.value || !element) return;
+
+  clearAnnotation();
+
+  const currentAnnotation = annotate(element, {
+    type: props.action,
+    color: props.color,
+    strokeWidth: props.strokeWidth,
+    animationDuration: props.animationDuration,
+    iterations: props.iterations,
+    padding: props.padding,
+    multiline: props.multiline,
+  });
+
+  annotation = currentAnnotation;
+  currentAnnotation.show();
+
+  resizeObserver = new ResizeObserver(() => {
+    currentAnnotation.hide();
+    currentAnnotation.show();
+  });
+  resizeObserver.observe(element);
+  resizeObserver.observe(document.body);
+}
+
+onMounted(() => {
+  const element = elementRef.value;
+  if (!element) return;
+
+  if (!props.isView) {
+    shouldShow.value = true;
+    return;
+  }
+
+  intersectionObserver = new IntersectionObserver(
+    (entries) => {
+      const entry = entries[0];
+      if (entry?.isIntersecting) {
+        shouldShow.value = true;
+        intersectionObserver?.disconnect();
+        intersectionObserver = null;
+      }
+    },
+    { rootMargin: "-10%" },
+  );
+  intersectionObserver.observe(element);
+});
+
+watch(
+  [
+    shouldShow,
+    () => props.action,
+    () => props.color,
+    () => props.strokeWidth,
+    () => props.animationDuration,
+    () => props.iterations,
+    () => props.padding,
+    () => props.multiline,
+  ],
+  () => draw(),
+  { flush: "post" },
+);
+
+onBeforeUnmount(() => {
+  clearAnnotation();
+  intersectionObserver?.disconnect();
+  intersectionObserver = null;
+});
+</script>
+
+<template>
+  <span
+    ref="elementRef"
+    :class="cn('relative inline-block bg-transparent', props.class)"
+  >
+    <slot />
+  </span>
+</template>
+```
+
+:::
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import Highlighter from "@/components/spark-ui/highlighter/highlighter.vue";
+</script>
+
+<template>
+  <p>
+    The
+    <Highlighter action="underline" color="#FF9800">
+      Spark UI Highlighter
+    </Highlighter>
+    makes important
+    <Highlighter action="highlight" color="#87CEFA">
+      text stand out
+    </Highlighter>
+    effortlessly.
+  </p>
+</template>
+```
+
+## Props
+
+| Prop                | Type                                                                                                | Default       | Description                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------- |
+| `action`            | `"highlight" \| "underline" \| "box" \| "circle" \| "strike-through" \| "crossed-off" \| "bracket"` | `"highlight"` | The type of annotation effect to apply.                                       |
+| `color`             | `string`                                                                                            | `"#ffd1dc"`   | The color of the annotation.                                                  |
+| `strokeWidth`       | `number`                                                                                            | `1.5`         | The width of the annotation stroke (in px).                                   |
+| `animationDuration` | `number`                                                                                            | `600`         | Duration of the animation in milliseconds.                                   |
+| `iterations`        | `number`                                                                                            | `2`           | Number of times to draw the annotation (adds a sketchy effect when > 1).      |
+| `padding`           | `number`                                                                                            | `2`           | Padding between the element and the annotation (in px).                       |
+| `multiline`         | `boolean`                                                                                           | `true`        | Whether to annotate across multiple lines or treat content as a single line.  |
+| `isView`            | `boolean`                                                                                           | `false`       | Controls whether the animation starts only when the element enters viewport.  |
+| `class`             | `string`                                                                                            | `undefined`   | Additional classes to merge onto the wrapper element.                         |
+
+## Slots
+
+| Slot      | Description                                |
+| --------- | ------------------------------------------ |
+| `default` | The content to be highlighted/annotated.   |

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,6 +20,7 @@
     "cobe": "^0.6.3",
     "fs-extra": "^11.2.0",
     "markdown-it": "^14.1.0",
+    "rough-notation": "^0.5.1",
     "svg-dotted-map": "^2.1.0",
     "tailwind-merge": "^2.5.3",
     "vitepress-plugin-group-icons": "^1.2.4",

--- a/docs/src/components/spark-ui/highlighter/highlighter.vue
+++ b/docs/src/components/spark-ui/highlighter/highlighter.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, ref, watch } from "vue";
+import { annotate } from "rough-notation";
+import type { RoughAnnotation } from "rough-notation/lib/model";
+import { cn } from "../../../lib/utils";
+
+type AnnotationAction =
+  | "highlight"
+  | "underline"
+  | "box"
+  | "circle"
+  | "strike-through"
+  | "crossed-off"
+  | "bracket";
+
+interface HighlighterProps {
+  class?: string;
+  action?: AnnotationAction;
+  color?: string;
+  strokeWidth?: number;
+  animationDuration?: number;
+  iterations?: number;
+  padding?: number;
+  multiline?: boolean;
+  isView?: boolean;
+}
+
+const props = withDefaults(defineProps<HighlighterProps>(), {
+  action: "highlight",
+  color: "#ffd1dc",
+  strokeWidth: 1.5,
+  animationDuration: 600,
+  iterations: 2,
+  padding: 2,
+  multiline: true,
+  isView: false,
+});
+
+const elementRef = ref<HTMLSpanElement | null>(null);
+const shouldShow = ref(false);
+
+let annotation: RoughAnnotation | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let intersectionObserver: IntersectionObserver | null = null;
+
+function clearAnnotation() {
+  annotation?.remove();
+  annotation = null;
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+}
+
+function draw() {
+  const element = elementRef.value;
+  if (!shouldShow.value || !element) return;
+
+  clearAnnotation();
+
+  const currentAnnotation = annotate(element, {
+    type: props.action,
+    color: props.color,
+    strokeWidth: props.strokeWidth,
+    animationDuration: props.animationDuration,
+    iterations: props.iterations,
+    padding: props.padding,
+    multiline: props.multiline,
+  });
+
+  annotation = currentAnnotation;
+  currentAnnotation.show();
+
+  resizeObserver = new ResizeObserver(() => {
+    currentAnnotation.hide();
+    currentAnnotation.show();
+  });
+  resizeObserver.observe(element);
+  resizeObserver.observe(document.body);
+}
+
+onMounted(() => {
+  const element = elementRef.value;
+  if (!element) return;
+
+  if (!props.isView) {
+    shouldShow.value = true;
+    return;
+  }
+
+  intersectionObserver = new IntersectionObserver(
+    (entries) => {
+      const entry = entries[0];
+      if (entry?.isIntersecting) {
+        shouldShow.value = true;
+        intersectionObserver?.disconnect();
+        intersectionObserver = null;
+      }
+    },
+    { rootMargin: "-10%" },
+  );
+  intersectionObserver.observe(element);
+});
+
+watch(
+  [
+    shouldShow,
+    () => props.action,
+    () => props.color,
+    () => props.strokeWidth,
+    () => props.animationDuration,
+    () => props.iterations,
+    () => props.padding,
+    () => props.multiline,
+  ],
+  () => draw(),
+  { flush: "post" },
+);
+
+onBeforeUnmount(() => {
+  clearAnnotation();
+  intersectionObserver?.disconnect();
+  intersectionObserver = null;
+});
+</script>
+
+<template>
+  <span
+    ref="elementRef"
+    :class="cn('relative inline-block bg-transparent', props.class)"
+  >
+    <slot />
+  </span>
+</template>

--- a/docs/src/example/highlighter/demo.vue
+++ b/docs/src/example/highlighter/demo.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import Highlighter from "./highlighter.vue";
+</script>
+
+<template>
+  <div class="text-center">
+    <p class="text-lg leading-relaxed md:w-[500px]">
+      The
+      <Highlighter action="underline" color="#FF9800">
+        Spark UI Highlighter
+      </Highlighter>
+      makes important
+      <Highlighter action="highlight" color="#87CEFA">
+        text stand out
+      </Highlighter>
+      effortlessly.
+    </p>
+  </div>
+</template>

--- a/docs/src/example/highlighter/highlighter.vue
+++ b/docs/src/example/highlighter/highlighter.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, ref, watch } from "vue";
+import { annotate } from "rough-notation";
+import type { RoughAnnotation } from "rough-notation/lib/model";
+import { cn } from "../../lib/utils";
+
+type AnnotationAction =
+  | "highlight"
+  | "underline"
+  | "box"
+  | "circle"
+  | "strike-through"
+  | "crossed-off"
+  | "bracket";
+
+interface HighlighterProps {
+  class?: string;
+  action?: AnnotationAction;
+  color?: string;
+  strokeWidth?: number;
+  animationDuration?: number;
+  iterations?: number;
+  padding?: number;
+  multiline?: boolean;
+  isView?: boolean;
+}
+
+const props = withDefaults(defineProps<HighlighterProps>(), {
+  action: "highlight",
+  color: "#ffd1dc",
+  strokeWidth: 1.5,
+  animationDuration: 600,
+  iterations: 2,
+  padding: 2,
+  multiline: true,
+  isView: false,
+});
+
+const elementRef = ref<HTMLSpanElement | null>(null);
+const shouldShow = ref(false);
+
+let annotation: RoughAnnotation | null = null;
+let resizeObserver: ResizeObserver | null = null;
+let intersectionObserver: IntersectionObserver | null = null;
+
+function clearAnnotation() {
+  annotation?.remove();
+  annotation = null;
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+}
+
+function draw() {
+  const element = elementRef.value;
+  if (!shouldShow.value || !element) return;
+
+  clearAnnotation();
+
+  const currentAnnotation = annotate(element, {
+    type: props.action,
+    color: props.color,
+    strokeWidth: props.strokeWidth,
+    animationDuration: props.animationDuration,
+    iterations: props.iterations,
+    padding: props.padding,
+    multiline: props.multiline,
+  });
+
+  annotation = currentAnnotation;
+  currentAnnotation.show();
+
+  resizeObserver = new ResizeObserver(() => {
+    currentAnnotation.hide();
+    currentAnnotation.show();
+  });
+  resizeObserver.observe(element);
+  resizeObserver.observe(document.body);
+}
+
+onMounted(() => {
+  const element = elementRef.value;
+  if (!element) return;
+
+  if (!props.isView) {
+    shouldShow.value = true;
+    return;
+  }
+
+  intersectionObserver = new IntersectionObserver(
+    (entries) => {
+      const entry = entries[0];
+      if (entry?.isIntersecting) {
+        shouldShow.value = true;
+        intersectionObserver?.disconnect();
+        intersectionObserver = null;
+      }
+    },
+    { rootMargin: "-10%" },
+  );
+  intersectionObserver.observe(element);
+});
+
+watch(
+  [
+    shouldShow,
+    () => props.action,
+    () => props.color,
+    () => props.strokeWidth,
+    () => props.animationDuration,
+    () => props.iterations,
+    () => props.padding,
+    () => props.multiline,
+  ],
+  () => draw(),
+  { flush: "post" },
+);
+
+onBeforeUnmount(() => {
+  clearAnnotation();
+  intersectionObserver?.disconnect();
+  intersectionObserver = null;
+});
+</script>
+
+<template>
+  <span
+    ref="elementRef"
+    :class="cn('relative inline-block bg-transparent', props.class)"
+  >
+    <slot />
+  </span>
+</template>

--- a/docs/src/spark-ui-demos/highlighter/highlighter.vue
+++ b/docs/src/spark-ui-demos/highlighter/highlighter.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import Highlighter from "../../components/spark-ui/highlighter/highlighter.vue";
+</script>
+
+<template>
+  <div class="text-center">
+    <p class="text-lg leading-relaxed md:w-[500px]">
+      The
+      <Highlighter action="underline" color="#FF9800">
+        Spark UI Highlighter
+      </Highlighter>
+      makes important
+      <Highlighter action="highlight" color="#87CEFA">
+        text stand out
+      </Highlighter>
+      effortlessly.
+    </p>
+  </div>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 2.1.0(react@18.3.1)
       vitepress-plugin-group-icons:
         specifier: ^1.7.5
-        version: 1.7.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))
+        version: 1.7.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@5.9.3))
@@ -59,7 +59,7 @@ importers:
         version: 22.19.19
       '@vitejs/plugin-vue':
         specifier: ^5.2.4
-        version: 5.2.4(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
+        version: 5.2.4(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(@voidzero-dev/vite-plus-test@0.1.24)
@@ -110,22 +110,22 @@ importers:
         version: 3.4.19(tsx@4.22.3)(yaml@2.9.0)
       unocss:
         specifier: ^0.63.6
-        version: 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(postcss@8.5.15)(rollup@4.61.0)(typescript@5.9.3)
+        version: 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(postcss@8.5.15)(rollup@4.61.0)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.19.19)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
+        version: 4.5.4(@types/node@22.19.19)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
+        version: 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.52.1)(@types/node@22.19.19)(lightningcss@1.32.0)(postcss@8.5.15)(react@18.3.1)(sass@1.100.0)(search-insights@2.17.3)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
       vue:
         specifier: ^3.5.35
         version: 3.5.35(typescript@5.9.3)
@@ -153,6 +153,9 @@ importers:
       markdown-it:
         specifier: ^14.1.0
         version: 14.2.0
+      rough-notation:
+        specifier: ^0.5.1
+        version: 0.5.1
       svg-dotted-map:
         specifier: ^2.1.0
         version: 2.1.0
@@ -3576,6 +3579,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rough-notation@0.5.1:
+    resolution: {integrity: sha512-ITHofTzm13cWFVfoGsh/4c/k2Mg8geKgBCwex71UZLnNuw403tCRjYPQ68jSAd37DMbZIePXPjDgY0XdZi9HPw==}
+
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -5315,13 +5321,13 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@unocss/astro@0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)':
+  '@unocss/astro@0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)':
     dependencies:
       '@unocss/core': 0.63.6
       '@unocss/reset': 0.63.6
-      '@unocss/vite': 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
+      '@unocss/vite': 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -5462,7 +5468,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.63.6
 
-  '@unocss/vite@0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)':
+  '@unocss/vite@0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.3.0(rollup@4.61.0)
@@ -5472,7 +5478,7 @@ snapshots:
       chokidar: 3.6.0
       magic-string: 0.30.21
       tinyglobby: 0.2.17
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -5496,9 +5502,9 @@ snapshots:
 
   '@vercel/edge@1.3.1': {}
 
-  '@vitejs/plugin-vue@5.2.4(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.35(typescript@5.9.3))':
     dependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
       vue: 3.5.35(typescript@5.9.3)
 
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.100.0))(vue@3.5.35(typescript@5.9.3))':
@@ -5518,7 +5524,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5533,7 +5539,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -5541,7 +5547,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
@@ -5549,7 +5555,7 @@ snapshots:
       postcss: 8.5.15
     optionalDependencies:
       '@types/node': 22.19.19
-      esbuild: 0.28.0
+      esbuild: 0.23.1
       fsevents: 2.3.3
       jiti: 2.7.0
       sass: 1.100.0
@@ -5575,11 +5581,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.24':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)':
+  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.2.0
@@ -5589,7 +5595,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.2.2
       tinyglobby: 0.2.17
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
       ws: 8.21.0
     optionalDependencies:
       '@types/node': 22.19.19
@@ -7059,7 +7065,7 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)):
+  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -7082,7 +7088,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.52.0
       '@oxfmt/binding-win32-ia32-msvc': 0.52.0
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      vite-plus: 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
+      vite-plus: 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -7093,7 +7099,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)):
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.67.0
       '@oxlint/binding-android-arm64': 1.67.0
@@ -7115,7 +7121,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.67.0
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
+      vite-plus: 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
 
   p-limit@3.1.0:
     dependencies:
@@ -7340,6 +7346,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.61.0
       '@rollup/rollup-win32-x64-msvc': 4.61.0
       fsevents: 2.3.3
+
+  rough-notation@0.5.1: {}
 
   rrweb-cssom@0.7.1: {}
 
@@ -7644,9 +7652,9 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss@0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(postcss@8.5.15)(rollup@4.61.0)(typescript@5.9.3):
+  unocss@0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(postcss@8.5.15)(rollup@4.61.0)(typescript@5.9.3):
     dependencies:
-      '@unocss/astro': 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
+      '@unocss/astro': 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
       '@unocss/cli': 0.63.6(rollup@4.61.0)
       '@unocss/core': 0.63.6
       '@unocss/postcss': 0.63.6(postcss@8.5.15)
@@ -7662,9 +7670,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.63.6
       '@unocss/transformer-directives': 0.63.6
       '@unocss/transformer-variant-group': 0.63.6
-      '@unocss/vite': 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
+      '@unocss/vite': 0.63.6(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3)
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -7737,7 +7745,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-dts@4.5.4(@types/node@22.19.19)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3):
+  vite-plugin-dts@4.5.4(@types/node@22.19.19)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(rollup@4.61.0)(typescript@5.9.3):
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@22.19.19)
       '@rollup/pluginutils': 5.3.0(rollup@4.61.0)
@@ -7750,7 +7758,7 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -7760,14 +7768,14 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0):
+  vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
-      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
+      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@22.19.19)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@vitest/ui@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.23.1)(jiti@2.7.0)(jsdom@25.0.1)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
@@ -7838,13 +7846,13 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitepress-plugin-group-icons@1.7.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)):
+  vitepress-plugin-group-icons@1.7.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)):
     dependencies:
       '@iconify-json/logos': 1.2.11
       '@iconify-json/vscode-icons': 1.2.51
       '@iconify/utils': 3.1.3
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@22.19.19)(esbuild@0.23.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)'
 
   vitepress-plugin-group-icons@1.7.5(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:

--- a/tests/highlighter/highlighter.spec.ts
+++ b/tests/highlighter/highlighter.spec.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+/// <reference lib="dom" />
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import { nextTick } from "vue";
+import Highlighter from "../../docs/src/components/spark-ui/highlighter/highlighter.vue";
+
+// jsdom lacks SVG geometry APIs that rough-notation relies on.
+const svgProto = SVGElement.prototype as unknown as Record<string, unknown>;
+svgProto.getTotalLength = () => 100;
+svgProto.getPointAtLength = () => ({ x: 0, y: 0 });
+svgProto.getBBox = () => ({ x: 0, y: 0, width: 100, height: 20 });
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+let intersectCallback: ((entries: unknown[]) => void) | null = null;
+class IntersectionObserverStub {
+  constructor(cb: (entries: unknown[]) => void) {
+    intersectCallback = cb;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver =
+  ResizeObserverStub as unknown as typeof ResizeObserver;
+globalThis.IntersectionObserver =
+  IntersectionObserverStub as unknown as typeof IntersectionObserver;
+
+it("renders slot content inside a styled span", () => {
+  const wrapper = mount(Highlighter, { slots: { default: "hello" } });
+  const span = wrapper.get("span");
+  expect(span.text()).toBe("hello");
+  expect(span.classes()).toContain("relative");
+  expect(span.classes()).toContain("inline-block");
+  expect(span.classes()).toContain("bg-transparent");
+});
+
+it("draws a rough-notation svg annotation on mount by default", async () => {
+  const wrapper = mount(Highlighter, {
+    attachTo: document.body,
+    slots: { default: "text" },
+  });
+  await nextTick();
+  await nextTick();
+  const svg = wrapper.get("span").element.parentElement!.querySelector("svg.rough-annotation");
+  expect(svg).not.toBeNull();
+  wrapper.unmount();
+});
+
+it("does not draw immediately when isView is true until it enters the viewport", async () => {
+  intersectCallback = null;
+  const wrapper = mount(Highlighter, {
+    attachTo: document.body,
+    props: { isView: true },
+    slots: { default: "text" },
+  });
+  await nextTick();
+  await nextTick();
+  const parent = wrapper.get("span").element.parentElement!;
+  expect(parent.querySelector("svg.rough-annotation")).toBeNull();
+
+  const trigger = intersectCallback as
+    | ((entries: unknown[]) => void)
+    | null;
+  trigger?.([{ isIntersecting: true }]);
+  await nextTick();
+  await nextTick();
+  expect(parent.querySelector("svg.rough-annotation")).not.toBeNull();
+  wrapper.unmount();
+});
+
+it("draws the annotation for a non-highlight action", async () => {
+  const wrapper = mount(Highlighter, {
+    attachTo: document.body,
+    props: { action: "underline", color: "#FF9800" },
+    slots: { default: "text" },
+  });
+  await nextTick();
+  await nextTick();
+  // Non-highlight annotations are inserted directly after the target element.
+  const span = wrapper.get("span").element;
+  expect(
+    span.nextElementSibling?.classList.contains("rough-annotation"),
+  ).toBe(true);
+  wrapper.unmount();
+});
+
+it("removes the annotation svg on unmount", async () => {
+  const wrapper = mount(Highlighter, {
+    attachTo: document.body,
+    slots: { default: "x" },
+  });
+  await nextTick();
+  await nextTick();
+  const parent = wrapper.get("span").element.parentElement!;
+  expect(parent.querySelector("svg.rough-annotation")).not.toBeNull();
+  wrapper.unmount();
+  expect(parent.querySelector("svg.rough-annotation")).toBeNull();
+});
+
+it("merges a custom class onto the wrapper", () => {
+  const wrapper = mount(Highlighter, {
+    props: { class: "my-custom" },
+    slots: { default: "x" },
+  });
+  expect(wrapper.get("span").classes()).toContain("my-custom");
+});


### PR DESCRIPTION
Ports Magic UI's **Highlighter** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/highlighter/highlighter.vue` — hand-drawn marker/underline annotations via `rough-notation` (same framework-agnostic library upstream uses; added to `docs/package.json`, lockfile committed)
- All 9 upstream props preserved (`action`, `color`, `strokeWidth`, `animationDuration`, `iterations`, `padding`, `multiline`, `isView`, `class`); `useInView` → IntersectionObserver, `useLayoutEffect` → `onMounted` + post-flush `watch`, ResizeObserver redraw kept; SSR-safe
- Live demo, copy-paste source, docs page (installation incl. dependency step, usage, props/slots), one-line sidebar entry
- 6 passing tests in `tests/highlighter/`

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (6)
- Browser check ✅ — underline and highlight annotations drawn around the text, contained in the demo card