### PR TITLE
fix(dotted-map): fit demos inside demo card

### DIFF
--- a/docs/src/example/dotted-map/demo-2.vue
+++ b/docs/src/example/dotted-map/demo-2.vue
@@ -3,7 +3,7 @@ import DottedMap from "./dotted-map.vue";
 </script>
 
 <template>
-  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+  <div class="relative h-[440px] w-full max-w-[500px] overflow-hidden rounded-lg border">
     <DottedMap :dot-radius="0.1" />
   </div>
 </template>

--- a/docs/src/example/dotted-map/demo-3.vue
+++ b/docs/src/example/dotted-map/demo-3.vue
@@ -18,7 +18,7 @@ const markers: Marker[] = [
 </script>
 
 <template>
-  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+  <div class="relative h-[440px] w-full max-w-[500px] overflow-hidden rounded-lg border">
     <div
       class="absolute inset-0 bg-radial from-transparent to-background to-200%"
     />

--- a/docs/src/example/dotted-map/demo.vue
+++ b/docs/src/example/dotted-map/demo.vue
@@ -28,7 +28,7 @@ const id = "dotted-map-demo";
 </script>
 
 <template>
-  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+  <div class="relative h-[440px] w-full max-w-[500px] overflow-hidden rounded-lg border">
     <div
       class="absolute inset-0 bg-radial from-transparent to-background to-200%"
     />

--- a/docs/src/spark-ui-demos/dotted-map/dotted-map.vue
+++ b/docs/src/spark-ui-demos/dotted-map/dotted-map.vue
@@ -28,7 +28,7 @@ const id = "dotted-map-demo";
 </script>
 
 <template>
-  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+  <div class="relative h-[440px] w-full max-w-[500px] overflow-hidden rounded-lg border">
     <div
       class="absolute inset-0 bg-radial from-transparent to-background to-200%"
     />

--- a/docs/src/spark-ui-demos/dotted-map/pulse-marker.vue
+++ b/docs/src/spark-ui-demos/dotted-map/pulse-marker.vue
@@ -18,7 +18,7 @@ const markers: Marker[] = [
 </script>
 
 <template>
-  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+  <div class="relative h-[440px] w-full max-w-[500px] overflow-hidden rounded-lg border">
     <div
       class="absolute inset-0 bg-radial from-transparent to-background to-200%"
     />

--- a/docs/src/spark-ui-demos/dotted-map/smaller-dots.vue
+++ b/docs/src/spark-ui-demos/dotted-map/smaller-dots.vue
@@ -3,7 +3,7 @@ import DottedMap from "../../components/spark-ui/dotted-map/dotted-map.vue";
 </script>
 
 <template>
-  <div class="relative h-[500px] w-full overflow-hidden rounded-lg border">
+  <div class="relative h-[440px] w-full max-w-[500px] overflow-hidden rounded-lg border">
     <DottedMap :dot-radius="0.1" />
   </div>
 </template>


### PR DESCRIPTION
An automated containment sweep (DOM-measuring every element inside each demo card) flagged the Dotted Map demos overflowing the card's content box by 24px vertically — the only offender out of 20 audited component pages. This caps the demo wrappers at `h-[440px] max-w-[500px]` so all three demos fit the card exactly.