### PR TITLE
feat(hyper-text): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ import { applyPlugins } from "./plugins/code";
 import { markdownForAgentsPlugin } from "./plugins/markdownForAgents";
 
 const newComponents = [
+	{ text: "Hyper Text", link: "/content/components/hyper-text.md" },
 	{ text: "Animated Tooltip", link: "/content/components/animated-tooltip.md" },
 	{ text: "Terminal", link: "/content/components/terminal.md" },
 	{

--- a/docs/content/components/hyper-text.md
+++ b/docs/content/components/hyper-text.md
@@ -1,0 +1,223 @@
+# Hyper Text
+
+A text animation that scrambles letters before revealing the final text.
+
+<demo src="../../src/example/hyper-text/demo.vue" srcCode="../../src/spark-ui-demos/hyper-text/hyper-text.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [hyper-text.vue]
+<script setup lang="ts">
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useSlots,
+  watch,
+} from "vue";
+import { cn } from "@/lib/utils";
+
+type CharacterSet = string[] | readonly string[];
+
+type HyperTextTag =
+  | "article"
+  | "div"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "li"
+  | "p"
+  | "section"
+  | "span";
+
+interface HyperTextProps {
+  /** The text content to animate (alternative to the default slot) */
+  text?: string;
+  /** Optional className for styling */
+  class?: string;
+  /** Duration of the animation in milliseconds */
+  duration?: number;
+  /** Delay before animation starts in milliseconds */
+  delay?: number;
+  /** Element to render as - defaults to div */
+  as?: HyperTextTag;
+  /** Whether to start animation when element comes into view */
+  startOnView?: boolean;
+  /** Whether to trigger animation on hover */
+  animateOnHover?: boolean;
+  /** Custom character set for scramble effect. Defaults to uppercase alphabet */
+  characterSet?: CharacterSet;
+}
+
+const props = withDefaults(defineProps<HyperTextProps>(), {
+  duration: 800,
+  delay: 0,
+  as: "div",
+  startOnView: false,
+  animateOnHover: true,
+  characterSet: () =>
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("") as readonly string[],
+});
+
+const slots = useSlots();
+
+const getRandomInt = (max: number): number => Math.floor(Math.random() * max);
+
+const slotText = (): string => {
+  const nodes = slots.default?.() ?? [];
+  return nodes
+    .map((node) => (typeof node.children === "string" ? node.children : ""))
+    .join("");
+};
+
+const sourceText = computed(() => props.text ?? slotText());
+
+const displayText = ref<string[]>(sourceText.value.split(""));
+const elementRef = ref<HTMLElement | null>(null);
+
+let animationFrameId: number | null = null;
+let startTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let observer: IntersectionObserver | null = null;
+let isAnimating = false;
+
+const cancelAnimation = () => {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+};
+
+const startAnimation = () => {
+  const chars = sourceText.value.split("");
+  const maxIterations = chars.length;
+  const startTime = performance.now();
+  isAnimating = true;
+
+  const animate = (currentTime: number) => {
+    const elapsed = currentTime - startTime;
+    const progress = Math.min(elapsed / props.duration, 1);
+    const iteration = progress * maxIterations;
+
+    displayText.value = chars.map((letter, index) =>
+      letter === " "
+        ? letter
+        : index <= iteration
+          ? chars[index]
+          : props.characterSet[getRandomInt(props.characterSet.length)],
+    );
+
+    if (progress < 1) {
+      animationFrameId = requestAnimationFrame(animate);
+    } else {
+      animationFrameId = null;
+      isAnimating = false;
+    }
+  };
+
+  cancelAnimation();
+  animationFrameId = requestAnimationFrame(animate);
+};
+
+const handleHover = () => {
+  if (props.animateOnHover && !isAnimating) {
+    startAnimation();
+  }
+};
+
+// Keep displayText in sync when the source text changes and no animation runs.
+watch(sourceText, (next) => {
+  if (!isAnimating) {
+    displayText.value = next.split("");
+  }
+});
+
+onMounted(() => {
+  if (!props.startOnView) {
+    startTimeoutId = setTimeout(startAnimation, props.delay);
+    return;
+  }
+
+  observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        startTimeoutId = setTimeout(startAnimation, props.delay);
+        observer?.disconnect();
+      }
+    },
+    { threshold: 0.1, rootMargin: "-30% 0px -30% 0px" },
+  );
+
+  if (elementRef.value) {
+    observer.observe(elementRef.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  cancelAnimation();
+  if (startTimeoutId !== null) clearTimeout(startTimeoutId);
+  observer?.disconnect();
+});
+
+const rootClass = computed(() =>
+  cn("overflow-hidden py-2 text-4xl font-bold", props.class),
+);
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    ref="elementRef"
+    :class="rootClass"
+    @mouseenter="handleHover"
+  >
+    <span
+      v-for="(letter, index) in displayText"
+      :key="index"
+      :class="cn('font-mono', letter === ' ' ? 'w-3' : '')"
+    >
+      {{ letter.toUpperCase() }}
+    </span>
+  </component>
+</template>
+```
+
+:::
+
+## Usage
+
+Pass the text as the default slot (matching the upstream `children` API), or use the `text` prop:
+
+```vue
+<HyperText>Hover Me!</HyperText>
+```
+
+```vue
+<HyperText text="Hover Me!" />
+```
+
+## Props
+
+| Prop             | Type                                                                                                       | Default | Description                                             |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------- |
+| `text`           | `string`                                                                                                   | `-`     | Text content to animate (alternative to default slot).  |
+| `class`          | `string`                                                                                                   | `-`     | The class name to be applied to the component.          |
+| `duration`       | `number`                                                                                                   | `800`   | Duration of the animation in milliseconds.              |
+| `delay`          | `number`                                                                                                   | `0`     | Delay before animation starts (in ms).                  |
+| `as`             | `"article" \| "div" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "li" \| "p" \| "section" \| "span"` | `"div"` | Element to render as.                                   |
+| `startOnView`    | `boolean`                                                                                                  | `false` | Start animation when the component scrolls into view.   |
+| `animateOnHover` | `boolean`                                                                                                  | `true`  | Re-trigger the scramble animation on hover.             |
+| `characterSet`   | `string[]`                                                                                                 | `A-Z`   | Custom character set for the scramble effect.           |
+
+## Slots
+
+| Slot      | Description                                             |
+| --------- | ------------------------------------------------------ |
+| `default` | The text to animate (used when the `text` prop is unset). |

--- a/docs/src/components/spark-ui/hyper-text/hyper-text.vue
+++ b/docs/src/components/spark-ui/hyper-text/hyper-text.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useSlots,
+  watch,
+} from "vue";
+import { cn } from "../../../lib/utils";
+
+type CharacterSet = string[] | readonly string[];
+
+type HyperTextTag =
+  | "article"
+  | "div"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "li"
+  | "p"
+  | "section"
+  | "span";
+
+interface HyperTextProps {
+  /** The text content to animate (alternative to the default slot) */
+  text?: string;
+  /** Optional className for styling */
+  class?: string;
+  /** Duration of the animation in milliseconds */
+  duration?: number;
+  /** Delay before animation starts in milliseconds */
+  delay?: number;
+  /** Element to render as - defaults to div */
+  as?: HyperTextTag;
+  /** Whether to start animation when element comes into view */
+  startOnView?: boolean;
+  /** Whether to trigger animation on hover */
+  animateOnHover?: boolean;
+  /** Custom character set for scramble effect. Defaults to uppercase alphabet */
+  characterSet?: CharacterSet;
+}
+
+const props = withDefaults(defineProps<HyperTextProps>(), {
+  duration: 800,
+  delay: 0,
+  as: "div",
+  startOnView: false,
+  animateOnHover: true,
+  characterSet: () =>
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("") as readonly string[],
+});
+
+const slots = useSlots();
+
+const getRandomInt = (max: number): number => Math.floor(Math.random() * max);
+
+const slotText = (): string => {
+  const nodes = slots.default?.() ?? [];
+  return nodes
+    .map((node) => (typeof node.children === "string" ? node.children : ""))
+    .join("");
+};
+
+const sourceText = computed(() => props.text ?? slotText());
+
+const displayText = ref<string[]>(sourceText.value.split(""));
+const elementRef = ref<HTMLElement | null>(null);
+
+let animationFrameId: number | null = null;
+let startTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let observer: IntersectionObserver | null = null;
+let isAnimating = false;
+
+const cancelAnimation = () => {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+};
+
+const startAnimation = () => {
+  const chars = sourceText.value.split("");
+  const maxIterations = chars.length;
+  const startTime = performance.now();
+  isAnimating = true;
+
+  const animate = (currentTime: number) => {
+    const elapsed = currentTime - startTime;
+    const progress = Math.min(elapsed / props.duration, 1);
+    const iteration = progress * maxIterations;
+
+    displayText.value = chars.map((letter, index) =>
+      letter === " "
+        ? letter
+        : index <= iteration
+          ? chars[index]
+          : props.characterSet[getRandomInt(props.characterSet.length)],
+    );
+
+    if (progress < 1) {
+      animationFrameId = requestAnimationFrame(animate);
+    } else {
+      animationFrameId = null;
+      isAnimating = false;
+    }
+  };
+
+  cancelAnimation();
+  animationFrameId = requestAnimationFrame(animate);
+};
+
+const handleHover = () => {
+  if (props.animateOnHover && !isAnimating) {
+    startAnimation();
+  }
+};
+
+// Keep displayText in sync when the source text changes and no animation runs.
+watch(sourceText, (next) => {
+  if (!isAnimating) {
+    displayText.value = next.split("");
+  }
+});
+
+onMounted(() => {
+  if (!props.startOnView) {
+    startTimeoutId = setTimeout(startAnimation, props.delay);
+    return;
+  }
+
+  observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        startTimeoutId = setTimeout(startAnimation, props.delay);
+        observer?.disconnect();
+      }
+    },
+    { threshold: 0.1, rootMargin: "-30% 0px -30% 0px" },
+  );
+
+  if (elementRef.value) {
+    observer.observe(elementRef.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  cancelAnimation();
+  if (startTimeoutId !== null) clearTimeout(startTimeoutId);
+  observer?.disconnect();
+});
+
+const rootClass = computed(() =>
+  cn("overflow-hidden py-2 text-4xl font-bold", props.class),
+);
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    ref="elementRef"
+    :class="rootClass"
+    @mouseenter="handleHover"
+  >
+    <span
+      v-for="(letter, index) in displayText"
+      :key="index"
+      :class="cn('font-mono', letter === ' ' ? 'w-3' : '')"
+    >
+      {{ letter.toUpperCase() }}
+    </span>
+  </component>
+</template>

--- a/docs/src/example/hyper-text/demo.vue
+++ b/docs/src/example/hyper-text/demo.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import HyperText from "./hyper-text.vue";
+</script>
+
+<template>
+  <div
+    class="flex w-[300px] md:w-[500px] items-center justify-center rounded-lg p-8"
+  >
+    <HyperText>Hover Me!</HyperText>
+  </div>
+</template>

--- a/docs/src/example/hyper-text/hyper-text.vue
+++ b/docs/src/example/hyper-text/hyper-text.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useSlots,
+  watch,
+} from "vue";
+import { cn } from "../../lib/utils";
+
+type CharacterSet = string[] | readonly string[];
+
+type HyperTextTag =
+  | "article"
+  | "div"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "li"
+  | "p"
+  | "section"
+  | "span";
+
+interface HyperTextProps {
+  /** The text content to animate (alternative to the default slot) */
+  text?: string;
+  /** Optional className for styling */
+  class?: string;
+  /** Duration of the animation in milliseconds */
+  duration?: number;
+  /** Delay before animation starts in milliseconds */
+  delay?: number;
+  /** Element to render as - defaults to div */
+  as?: HyperTextTag;
+  /** Whether to start animation when element comes into view */
+  startOnView?: boolean;
+  /** Whether to trigger animation on hover */
+  animateOnHover?: boolean;
+  /** Custom character set for scramble effect. Defaults to uppercase alphabet */
+  characterSet?: CharacterSet;
+}
+
+const props = withDefaults(defineProps<HyperTextProps>(), {
+  duration: 800,
+  delay: 0,
+  as: "div",
+  startOnView: false,
+  animateOnHover: true,
+  characterSet: () =>
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("") as readonly string[],
+});
+
+const slots = useSlots();
+
+const getRandomInt = (max: number): number => Math.floor(Math.random() * max);
+
+const slotText = (): string => {
+  const nodes = slots.default?.() ?? [];
+  return nodes
+    .map((node) => (typeof node.children === "string" ? node.children : ""))
+    .join("");
+};
+
+const sourceText = computed(() => props.text ?? slotText());
+
+const displayText = ref<string[]>(sourceText.value.split(""));
+const elementRef = ref<HTMLElement | null>(null);
+
+let animationFrameId: number | null = null;
+let startTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let observer: IntersectionObserver | null = null;
+let isAnimating = false;
+
+const cancelAnimation = () => {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+};
+
+const startAnimation = () => {
+  const chars = sourceText.value.split("");
+  const maxIterations = chars.length;
+  const startTime = performance.now();
+  isAnimating = true;
+
+  const animate = (currentTime: number) => {
+    const elapsed = currentTime - startTime;
+    const progress = Math.min(elapsed / props.duration, 1);
+    const iteration = progress * maxIterations;
+
+    displayText.value = chars.map((letter, index) =>
+      letter === " "
+        ? letter
+        : index <= iteration
+          ? chars[index]
+          : props.characterSet[getRandomInt(props.characterSet.length)],
+    );
+
+    if (progress < 1) {
+      animationFrameId = requestAnimationFrame(animate);
+    } else {
+      animationFrameId = null;
+      isAnimating = false;
+    }
+  };
+
+  cancelAnimation();
+  animationFrameId = requestAnimationFrame(animate);
+};
+
+const handleHover = () => {
+  if (props.animateOnHover && !isAnimating) {
+    startAnimation();
+  }
+};
+
+// Keep displayText in sync when the source text changes and no animation runs.
+watch(sourceText, (next) => {
+  if (!isAnimating) {
+    displayText.value = next.split("");
+  }
+});
+
+onMounted(() => {
+  if (!props.startOnView) {
+    startTimeoutId = setTimeout(startAnimation, props.delay);
+    return;
+  }
+
+  observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        startTimeoutId = setTimeout(startAnimation, props.delay);
+        observer?.disconnect();
+      }
+    },
+    { threshold: 0.1, rootMargin: "-30% 0px -30% 0px" },
+  );
+
+  if (elementRef.value) {
+    observer.observe(elementRef.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  cancelAnimation();
+  if (startTimeoutId !== null) clearTimeout(startTimeoutId);
+  observer?.disconnect();
+});
+
+const rootClass = computed(() =>
+  cn("overflow-hidden py-2 text-4xl font-bold", props.class),
+);
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    ref="elementRef"
+    :class="rootClass"
+    @mouseenter="handleHover"
+  >
+    <span
+      v-for="(letter, index) in displayText"
+      :key="index"
+      :class="cn('font-mono', letter === ' ' ? 'w-3' : '')"
+    >
+      {{ letter.toUpperCase() }}
+    </span>
+  </component>
+</template>

--- a/docs/src/spark-ui-demos/hyper-text/hyper-text.vue
+++ b/docs/src/spark-ui-demos/hyper-text/hyper-text.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import HyperText from "../../components/spark-ui/hyper-text/hyper-text.vue";
+</script>
+
+<template>
+  <div
+    class="flex w-[300px] md:w-[500px] items-center justify-center rounded-lg p-8"
+  >
+    <HyperText>Hover Me!</HyperText>
+  </div>
+</template>

--- a/tests/hyper-text/hyper-text.spec.ts
+++ b/tests/hyper-text/hyper-text.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, expect, it, vi } from "vite-plus/test";
+import HyperText from "../../docs/src/components/spark-ui/hyper-text/hyper-text.vue";
+
+type RafCallback = (time: number) => void;
+let rafCallbacks: RafCallback[] = [];
+let now = 0;
+
+const setNow = (n: number) => {
+  now = n;
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  rafCallbacks = [];
+  now = 0;
+  vi.stubGlobal("requestAnimationFrame", (cb: RafCallback) => {
+    rafCallbacks.push(cb);
+    return rafCallbacks.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+  vi.spyOn(performance, "now").mockImplementation(() => now);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+const drainRaf = () => {
+  while (rafCallbacks.length) {
+    rafCallbacks.shift()?.(now);
+  }
+};
+
+it("renders the slot text split into per-character spans", () => {
+  const wrapper = mount(HyperText, { slots: { default: "Hi" } });
+  const spans = wrapper.findAll("span");
+  expect(spans).toHaveLength(2);
+});
+
+it("accepts the text prop as an alternative to the slot", () => {
+  const wrapper = mount(HyperText, { props: { text: "Yo" } });
+  expect(wrapper.findAll("span")).toHaveLength(2);
+});
+
+it("applies base classes and merges a custom class", () => {
+  const wrapper = mount(HyperText, {
+    props: { text: "AB", class: "text-red-500" },
+  });
+  const el = wrapper.get("div");
+  expect(el.classes()).toContain("overflow-hidden");
+  expect(el.classes()).toContain("font-bold");
+  expect(el.classes()).toContain("text-red-500");
+});
+
+it("renders as the requested element via the `as` prop", () => {
+  const wrapper = mount(HyperText, { props: { text: "AB", as: "h1" } });
+  expect(wrapper.find("h1").exists()).toBe(true);
+});
+
+it("resolves to the final text once the animation completes", async () => {
+  const wrapper = mount(HyperText, { props: { text: "AB", duration: 800 } });
+  // Fire the initial start timeout (delay = 0).
+  vi.advanceTimersByTime(0);
+  // First scramble frame at t=0.
+  setNow(0);
+  drainRaf();
+  // Final frame past the duration -> text settles.
+  setNow(1000);
+  drainRaf();
+  await flushPromises();
+  expect(wrapper.text().replace(/\s+/g, "")).toBe("AB");
+});
+
+it("uppercases the resolved characters", async () => {
+  const wrapper = mount(HyperText, { props: { text: "ab", duration: 800 } });
+  vi.advanceTimersByTime(0);
+  setNow(1000);
+  drainRaf();
+  await flushPromises();
+  expect(wrapper.text().replace(/\s+/g, "")).toBe("AB");
+});


### PR DESCRIPTION
Ports Magic UI's **Hyper Text** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/hyper-text/hyper-text.vue` — rAF scramble-reveal with per-character progression; props `duration`, `delay`, `as` (dynamic `<component :is>`), `startOnView` (IntersectionObserver, upstream threshold/rootMargin), `animateOnHover`, `characterSet`, `class`; upstream `children` preserved as the default slot (with a `text` prop alternative, both documented)
- SSR-safe; rAF/timeout/observer fully cleaned up on unmount
- Live demo, copy-paste source, docs page (installation, usage, props/slots), one-line sidebar entry
- 6 passing tests in `tests/hyper-text/`

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (6)
- Browser check ✅ — scramble frame (`HOVER ZIY`) then settled `HOVER ME!`; containment sweep reports zero overflow