### PR TITLE
feat(interactive-grid-pattern): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,7 @@ const newComponents = [
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
 	{ text: "Dotted Map", link: "/content/components/dotted-map.md" },
 	{ text: "Hexagon Pattern", link: "/content/components/hexagon-pattern.md" },
+	{ text: "Interactive Grid Pattern", link: "/content/components/interactive-grid-pattern.md" },
 ];
 
 const components = [

--- a/docs/content/components/interactive-grid-pattern.md
+++ b/docs/content/components/interactive-grid-pattern.md
@@ -1,0 +1,87 @@
+# Interactive Grid Pattern
+
+An interactive background grid pattern made with SVGs, fully customizable using Tailwind CSS.
+
+<demo src="../../src/example/interactive-grid-pattern/demo.vue" srcCode="../../src/spark-ui-demos/interactive-grid-pattern/interactive-grid-pattern.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [interactive-grid-pattern.vue]
+<script setup lang="ts">
+import { ref } from "vue";
+import { cn } from "@/lib/utils";
+
+interface InteractiveGridPatternProps {
+  width?: number;
+  height?: number;
+  squares?: [number, number];
+  class?: string;
+  squaresClassName?: string;
+}
+
+const props = withDefaults(defineProps<InteractiveGridPatternProps>(), {
+  width: 40,
+  height: 40,
+  squares: () => [24, 24],
+});
+
+const hoveredSquare = ref<number | null>(null);
+</script>
+
+<template>
+  <svg
+    :width="width * squares[0]"
+    :height="height * squares[1]"
+    :class="cn('absolute inset-0 h-full w-full border border-gray-400/30', props.class)"
+  >
+    <rect
+      v-for="(_, index) in squares[0] * squares[1]"
+      :key="index"
+      :x="(index % squares[0]) * width"
+      :y="Math.floor(index / squares[0]) * height"
+      :width="width"
+      :height="height"
+      :class="
+        cn(
+          'interactive-grid-square stroke-gray-400/30',
+          hoveredSquare === index ? 'fill-gray-300/30' : 'fill-transparent',
+          squaresClassName,
+        )
+      "
+      @mouseenter="hoveredSquare = index"
+      @mouseleave="hoveredSquare = null"
+    />
+  </svg>
+</template>
+
+<style scoped>
+.interactive-grid-square {
+  transition: all 1000ms ease-in-out;
+}
+.interactive-grid-square:hover {
+  transition-duration: 100ms;
+}
+</style>
+```
+
+:::
+
+## Examples
+
+### Colorful
+
+<demo src="../../src/example/interactive-grid-pattern/colorful-demo.vue" srcCode="../../src/spark-ui-demos/interactive-grid-pattern/colorful-interactive-grid-pattern.vue" />
+
+## Props
+
+| Prop               | Type               | Default    | Description                                                                                     |
+| ------------------ | ------------------ | ---------- | ----------------------------------------------------------------------------------------------- |
+| `width`            | `number`           | `40`       | Width of each square in the grid.                                                               |
+| `height`           | `number`           | `40`       | Height of each square in the grid.                                                              |
+| `squares`          | `[number, number]` | `[24, 24]` | Number of squares in the grid. First number is horizontal squares, second is vertical squares. |
+| `class`            | `string`           | `-`        | Class name applied to the grid container.                                                       |
+| `squaresClassName` | `string`           | `-`        | Class name applied to individual squares in the grid.                                           |

--- a/docs/src/components/spark-ui/interactive-grid-pattern/interactive-grid-pattern.vue
+++ b/docs/src/components/spark-ui/interactive-grid-pattern/interactive-grid-pattern.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface InteractiveGridPatternProps {
+  width?: number;
+  height?: number;
+  squares?: [number, number];
+  class?: string;
+  squaresClassName?: string;
+}
+
+const props = withDefaults(defineProps<InteractiveGridPatternProps>(), {
+  width: 40,
+  height: 40,
+  squares: () => [24, 24],
+});
+
+const hoveredSquare = ref<number | null>(null);
+</script>
+
+<template>
+  <svg
+    :width="width * squares[0]"
+    :height="height * squares[1]"
+    :class="cn('absolute inset-0 h-full w-full border border-gray-400/30', props.class)"
+  >
+    <rect
+      v-for="(_, index) in squares[0] * squares[1]"
+      :key="index"
+      :x="(index % squares[0]) * width"
+      :y="Math.floor(index / squares[0]) * height"
+      :width="width"
+      :height="height"
+      :class="
+        cn(
+          'interactive-grid-square stroke-gray-400/30',
+          hoveredSquare === index ? 'fill-gray-300/30' : 'fill-transparent',
+          squaresClassName,
+        )
+      "
+      @mouseenter="hoveredSquare = index"
+      @mouseleave="hoveredSquare = null"
+    />
+  </svg>
+</template>
+
+<style scoped>
+.interactive-grid-square {
+  transition: all 1000ms ease-in-out;
+}
+.interactive-grid-square:hover {
+  transition-duration: 100ms;
+}
+</style>

--- a/docs/src/example/interactive-grid-pattern/colorful-demo.vue
+++ b/docs/src/example/interactive-grid-pattern/colorful-demo.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+import InteractiveGridPattern from "./interactive-grid-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg border md:w-[500px]"
+  >
+    <InteractiveGridPattern
+      :width="20"
+      :height="20"
+      :squares="[80, 80]"
+      :class="cn('[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]')"
+      squares-class-name="hover:fill-blue-500"
+    />
+  </div>
+</template>

--- a/docs/src/example/interactive-grid-pattern/demo.vue
+++ b/docs/src/example/interactive-grid-pattern/demo.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+import InteractiveGridPattern from "./interactive-grid-pattern.vue";
+</script>
+
+<template>
+  <div
+    class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg border md:w-[500px]"
+  >
+    <InteractiveGridPattern
+      :class="
+        cn(
+          '[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]',
+          'inset-x-0 inset-y-[-30%] h-[200%] skew-y-12',
+        )
+      "
+    />
+  </div>
+</template>

--- a/docs/src/example/interactive-grid-pattern/interactive-grid-pattern.vue
+++ b/docs/src/example/interactive-grid-pattern/interactive-grid-pattern.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { cn } from "../../lib/utils";
+
+interface InteractiveGridPatternProps {
+  width?: number;
+  height?: number;
+  squares?: [number, number];
+  class?: string;
+  squaresClassName?: string;
+}
+
+const props = withDefaults(defineProps<InteractiveGridPatternProps>(), {
+  width: 40,
+  height: 40,
+  squares: () => [24, 24],
+});
+
+const hoveredSquare = ref<number | null>(null);
+</script>
+
+<template>
+  <svg
+    :width="width * squares[0]"
+    :height="height * squares[1]"
+    :class="cn('absolute inset-0 h-full w-full border border-gray-400/30', props.class)"
+  >
+    <rect
+      v-for="(_, index) in squares[0] * squares[1]"
+      :key="index"
+      :x="(index % squares[0]) * width"
+      :y="Math.floor(index / squares[0]) * height"
+      :width="width"
+      :height="height"
+      :class="
+        cn(
+          'interactive-grid-square stroke-gray-400/30',
+          hoveredSquare === index ? 'fill-gray-300/30' : 'fill-transparent',
+          squaresClassName,
+        )
+      "
+      @mouseenter="hoveredSquare = index"
+      @mouseleave="hoveredSquare = null"
+    />
+  </svg>
+</template>
+
+<style scoped>
+.interactive-grid-square {
+  transition: all 1000ms ease-in-out;
+}
+.interactive-grid-square:hover {
+  transition-duration: 100ms;
+}
+</style>

--- a/docs/src/spark-ui-demos/interactive-grid-pattern/colorful-interactive-grid-pattern.vue
+++ b/docs/src/spark-ui-demos/interactive-grid-pattern/colorful-interactive-grid-pattern.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import InteractiveGridPattern from "../../components/spark-ui/interactive-grid-pattern/interactive-grid-pattern.vue";
+import { cn } from "../../lib/utils";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg border md:w-[500px]"
+    >
+      <InteractiveGridPattern
+        :width="20"
+        :height="20"
+        :squares="[80, 80]"
+        :class="cn('[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]')"
+        squares-class-name="hover:fill-blue-500"
+      />
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/interactive-grid-pattern/interactive-grid-pattern.vue
+++ b/docs/src/spark-ui-demos/interactive-grid-pattern/interactive-grid-pattern.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import InteractiveGridPattern from "../../components/spark-ui/interactive-grid-pattern/interactive-grid-pattern.vue";
+import { cn } from "../../lib/utils";
+</script>
+
+<template>
+  <div class="grid place-items-center w-full min-h-screen">
+    <div
+      class="relative flex h-[450px] w-[300px] flex-col items-center justify-center overflow-hidden rounded-lg border md:w-[500px]"
+    >
+      <InteractiveGridPattern
+        :class="
+          cn(
+            '[mask-image:radial-gradient(400px_circle_at_center,white,transparent)]',
+            'inset-x-0 inset-y-[-30%] h-[200%] skew-y-12',
+          )
+        "
+      />
+    </div>
+  </div>
+</template>

--- a/tests/interactive-grid-pattern/interactive-grid-pattern.spec.ts
+++ b/tests/interactive-grid-pattern/interactive-grid-pattern.spec.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import InteractiveGridPattern from "../../docs/src/components/spark-ui/interactive-grid-pattern/interactive-grid-pattern.vue";
+
+it("renders the default 24x24 grid of squares", () => {
+  const wrapper = mount(InteractiveGridPattern);
+  expect(wrapper.findAll("rect").length).toBe(24 * 24);
+});
+
+it("sizes the svg from width/height and squares", () => {
+  const wrapper = mount(InteractiveGridPattern, {
+    props: { width: 20, height: 10, squares: [5, 3] },
+  });
+  const svg = wrapper.get("svg");
+  expect(svg.attributes("width")).toBe("100");
+  expect(svg.attributes("height")).toBe("30");
+  expect(wrapper.findAll("rect").length).toBe(15);
+});
+
+it("positions squares in a row-major layout", () => {
+  const wrapper = mount(InteractiveGridPattern, {
+    props: { width: 40, height: 40, squares: [2, 2] },
+  });
+  const rects = wrapper.findAll("rect");
+  // index 0 -> (0,0), index 1 -> (40,0), index 2 -> (0,40), index 3 -> (40,40)
+  expect(rects[1]?.attributes("x")).toBe("40");
+  expect(rects[1]?.attributes("y")).toBe("0");
+  expect(rects[2]?.attributes("x")).toBe("0");
+  expect(rects[2]?.attributes("y")).toBe("40");
+});
+
+it("merges a custom class onto the svg", () => {
+  const wrapper = mount(InteractiveGridPattern, { props: { class: "custom-mask" } });
+  const classes = wrapper.get("svg").classes();
+  expect(classes).toContain("absolute");
+  expect(classes).toContain("custom-mask");
+});
+
+it("applies squaresClassName to each square", () => {
+  const wrapper = mount(InteractiveGridPattern, {
+    props: { squares: [2, 2], squaresClassName: "hover:fill-blue-500" },
+  });
+  expect(wrapper.get("rect").classes()).toContain("hover:fill-blue-500");
+});
+
+it("highlights only the hovered square", async () => {
+  const wrapper = mount(InteractiveGridPattern, { props: { squares: [2, 2] } });
+  const rects = wrapper.findAll("rect");
+  await rects[1]?.trigger("mouseenter");
+  expect(rects[1]?.classes()).toContain("fill-gray-300/30");
+  expect(rects[0]?.classes()).toContain("fill-transparent");
+  await rects[1]?.trigger("mouseleave");
+  expect(rects[1]?.classes()).toContain("fill-transparent");
+});


### PR DESCRIPTION
Ports Magic UI's **Interactive Grid Pattern** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/interactive-grid-pattern/interactive-grid-pattern.vue` — SVG grid whose squares highlight on hover; props `width`, `height`, `squares`, `class`, `squaresClassName`; upstream's Tailwind-v4-only `not-[&:hover]:duration-1000` translated to scoped CSS with identical timing (100ms hover in, 1000ms fade out)
- Default + colorful demos with copy-paste sources
- Docs page, one-line sidebar entry, 6 passing tests

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (6)
- Browser check ✅ — hover screenshot shows highlighted squares; containment sweep reports zero overflow