### PR TITLE
feat(interactive-hover-button): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,7 @@ const newComponents = [
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
 	{ text: "Dotted Map", link: "/content/components/dotted-map.md" },
 	{ text: "Hexagon Pattern", link: "/content/components/hexagon-pattern.md" },
+	{ text: "Interactive Hover Button", link: "/content/components/interactive-hover-button.md" },
 ];
 
 const components = [

--- a/docs/content/components/interactive-hover-button.md
+++ b/docs/content/components/interactive-hover-button.md
@@ -1,0 +1,99 @@
+# Interactive Hover Button
+
+A visually engaging button that responds to hover with an expanding-dot transition and sliding text with an arrow, adapting smoothly between light and dark modes.
+
+<demo src="../../src/example/interactive-hover-button/demo.vue" srcCode="../../src/spark-ui-demos/interactive-hover-button/interactive-hover-button.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [interactive-hover-button.vue]
+<script setup lang="ts">
+import { cn } from "@/lib/utils";
+
+interface InteractiveHoverButtonProps {
+  class?: string;
+  [key: string]: any;
+}
+
+const props = defineProps<InteractiveHoverButtonProps>();
+</script>
+
+<template>
+  <button
+    v-bind="props"
+    :class="
+      cn(
+        'group relative w-auto cursor-pointer overflow-hidden rounded-full border border-solid border-black/10 bg-white p-2 px-6 text-center font-semibold text-black dark:border-white/10 dark:bg-black dark:text-white',
+        props.class,
+      )
+    "
+  >
+    <div class="flex items-center justify-center gap-2">
+      <div
+        class="h-2 w-2 rounded-full bg-black transition-all duration-300 group-hover:scale-[100.8] dark:bg-white"
+      ></div>
+      <span
+        class="inline-block transition-all duration-300 group-hover:translate-x-12 group-hover:opacity-0"
+      >
+        <slot />
+      </span>
+    </div>
+    <div
+      class="absolute top-0 z-10 flex h-full w-full translate-x-12 items-center justify-center gap-2 text-white opacity-0 transition-all duration-300 group-hover:-translate-x-5 group-hover:opacity-100 dark:text-black"
+    >
+      <span><slot /></span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M5 12h14" />
+        <path d="m12 5 7 7-7 7" />
+      </svg>
+    </div>
+  </button>
+</template>
+```
+
+:::
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import InteractiveHoverButton from "@/components/spark-ui/interactive-hover-button/interactive-hover-button.vue";
+</script>
+
+<template>
+  <InteractiveHoverButton>Hover Me</InteractiveHoverButton>
+</template>
+```
+
+## Props
+
+| Prop    | Type     | Default | Description                                   |
+| ------- | -------- | ------- | --------------------------------------------- |
+| `class` | `string` | `-`     | Additional class names to style the component |
+
+Any native `<button>` attributes (e.g. `disabled`, `type`, `@click`) fall through to the underlying element.
+
+## Slots
+
+| Slot      | Description                          |
+| --------- | ----------------------------------- |
+| `default` | The content displayed in the button |
+
+## Credits
+
+- Credit to [@AayushBharti](https://github.com/AayushBharti)
+- Ported from [Magic UI](https://magicui.design/docs/components/interactive-hover-button)

--- a/docs/src/components/spark-ui/interactive-hover-button/interactive-hover-button.vue
+++ b/docs/src/components/spark-ui/interactive-hover-button/interactive-hover-button.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { cn } from "../../../lib/utils";
+
+interface InteractiveHoverButtonProps {
+  class?: string;
+  [key: string]: any;
+}
+
+const props = defineProps<InteractiveHoverButtonProps>();
+</script>
+
+<template>
+  <button
+    v-bind="props"
+    :class="
+      cn(
+        'group relative w-auto cursor-pointer overflow-hidden rounded-full border border-solid border-black/10 bg-white p-2 px-6 text-center font-semibold text-black dark:border-white/10 dark:bg-black dark:text-white',
+        props.class,
+      )
+    "
+  >
+    <div class="flex items-center justify-center gap-2">
+      <div
+        class="h-2 w-2 rounded-full bg-black transition-all duration-300 group-hover:scale-[100.8] dark:bg-white"
+      ></div>
+      <span
+        class="inline-block transition-all duration-300 group-hover:translate-x-12 group-hover:opacity-0"
+      >
+        <slot />
+      </span>
+    </div>
+    <div
+      class="absolute top-0 z-10 flex h-full w-full translate-x-12 items-center justify-center gap-2 text-white opacity-0 transition-all duration-300 group-hover:-translate-x-5 group-hover:opacity-100 dark:text-black"
+    >
+      <span><slot /></span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M5 12h14" />
+        <path d="m12 5 7 7-7 7" />
+      </svg>
+    </div>
+  </button>
+</template>

--- a/docs/src/example/interactive-hover-button/demo.vue
+++ b/docs/src/example/interactive-hover-button/demo.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import InteractiveHoverButton from "./interactive-hover-button.vue";
+</script>
+
+<template>
+  <div class="flex h-[200px] w-[300px] items-center justify-center md:w-[500px]">
+    <InteractiveHoverButton>Hover Me</InteractiveHoverButton>
+  </div>
+</template>

--- a/docs/src/example/interactive-hover-button/interactive-hover-button.vue
+++ b/docs/src/example/interactive-hover-button/interactive-hover-button.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { cn } from "../../lib/utils";
+
+interface InteractiveHoverButtonProps {
+  class?: string;
+  [key: string]: any;
+}
+
+const props = defineProps<InteractiveHoverButtonProps>();
+</script>
+
+<template>
+  <button
+    v-bind="props"
+    :class="
+      cn(
+        'group relative w-auto cursor-pointer overflow-hidden rounded-full border border-solid border-black/10 bg-white p-2 px-6 text-center font-semibold text-black dark:border-white/10 dark:bg-black dark:text-white',
+        props.class,
+      )
+    "
+  >
+    <div class="flex items-center justify-center gap-2">
+      <div
+        class="h-2 w-2 rounded-full bg-black transition-all duration-300 group-hover:scale-[100.8] dark:bg-white"
+      ></div>
+      <span
+        class="inline-block transition-all duration-300 group-hover:translate-x-12 group-hover:opacity-0"
+      >
+        <slot />
+      </span>
+    </div>
+    <div
+      class="absolute top-0 z-10 flex h-full w-full translate-x-12 items-center justify-center gap-2 text-white opacity-0 transition-all duration-300 group-hover:-translate-x-5 group-hover:opacity-100 dark:text-black"
+    >
+      <span><slot /></span>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M5 12h14" />
+        <path d="m12 5 7 7-7 7" />
+      </svg>
+    </div>
+  </button>
+</template>

--- a/docs/src/spark-ui-demos/interactive-hover-button/interactive-hover-button.vue
+++ b/docs/src/spark-ui-demos/interactive-hover-button/interactive-hover-button.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import InteractiveHoverButton from "../../components/spark-ui/interactive-hover-button/interactive-hover-button.vue";
+</script>
+
+<template>
+  <div class="flex h-[200px] w-[300px] items-center justify-center md:w-[500px]">
+    <InteractiveHoverButton>Hover Me</InteractiveHoverButton>
+  </div>
+</template>

--- a/tests/interactive-hover-button/interactive-hover-button.spec.ts
+++ b/tests/interactive-hover-button/interactive-hover-button.spec.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import InteractiveHoverButton from "../../docs/src/components/spark-ui/interactive-hover-button/interactive-hover-button.vue";
+
+it("renders slot content in both text layers", () => {
+  const wrapper = mount(InteractiveHoverButton, { slots: { default: "Hover Me" } });
+  const spans = wrapper.findAll("span");
+  expect(spans).toHaveLength(2);
+  spans.forEach((span) => expect(span.text()).toBe("Hover Me"));
+});
+
+it("renders as a button with base styling and group class", () => {
+  const wrapper = mount(InteractiveHoverButton, { slots: { default: "Go" } });
+  const btn = wrapper.get("button");
+  expect(btn.classes()).toContain("group");
+  expect(btn.classes()).toContain("rounded-full");
+  expect(btn.classes()).toContain("overflow-hidden");
+});
+
+it("uses paired light/dark colors (no unresolved theme tokens)", () => {
+  const wrapper = mount(InteractiveHoverButton, { slots: { default: "Go" } });
+  const html = wrapper.html();
+  expect(html).toContain("bg-white");
+  expect(html).toContain("dark:bg-black");
+  expect(html).not.toContain("bg-primary");
+  expect(html).not.toContain("bg-background");
+  expect(html).not.toContain("text-primary-foreground");
+});
+
+it("renders the expanding dot with hover scale transition", () => {
+  const wrapper = mount(InteractiveHoverButton, { slots: { default: "Go" } });
+  const dot = wrapper.get("button > div > div");
+  expect(dot.classes()).toContain("group-hover:scale-[100.8]");
+  expect(dot.classes()).toContain("rounded-full");
+});
+
+it("renders an inline arrow svg", () => {
+  const wrapper = mount(InteractiveHoverButton, { slots: { default: "Go" } });
+  expect(wrapper.find("svg").exists()).toBe(true);
+});
+
+it("merges a custom class", () => {
+  const wrapper = mount(InteractiveHoverButton, {
+    props: { class: "my-custom" },
+    slots: { default: "Go" },
+  });
+  expect(wrapper.get("button").classes()).toContain("my-custom");
+});
+
+it("falls through native button attributes", () => {
+  const wrapper = mount(InteractiveHoverButton, {
+    attrs: { disabled: "", type: "submit" },
+    slots: { default: "Go" },
+  });
+  const btn = wrapper.get("button");
+  expect(btn.attributes("disabled")).toBeDefined();
+  expect(btn.attributes("type")).toBe("submit");
+});
+
+it("emits click events", async () => {
+  const wrapper = mount(InteractiveHoverButton, { slots: { default: "Go" } });
+  await wrapper.get("button").trigger("click");
+  expect(wrapper.emitted("click")).toBeTruthy();
+});


### PR DESCRIPTION
Ports Magic UI's **Interactive Hover Button** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/interactive-hover-button/interactive-hover-button.vue` — expanding-dot hover transition with sliding text + arrow; upstream `children` → default slot, native button attrs fall through; lucide ArrowRight → inline SVG
- Theme tokens translated to concrete paired colors (light/dark verified): resting white pill + black dot, hovered black fill + white text, inverted in dark mode; explicit `border-solid` for the no-Preflight environment
- Live demo, copy-paste source, docs page, one-line sidebar entry, 8 passing tests

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (8)
- Browser check ✅ — resting + hovered screenshots in light and dark; containment sweep reports zero overflow