### PR TITLE
fix: pair dark-mode text colors across component demos

### DIFF
--- a/docs/content/components/animated-list.md
+++ b/docs/content/components/animated-list.md
@@ -150,7 +150,7 @@ const className = cn(
       </div>
       <div class="flex flex-col overflow-hidden">
         <figcaption class="flex flex-row items-center whitespace-pre text-lg font-medium ">
-          <span class="text-sm text-black sm:text-lg">{{ props.name }}</span>
+          <span class="text-sm text-black dark:text-white sm:text-lg">{{ props.name }}</span>
           <span class="mx-1">·</span>
           <span class="text-xs text-gray-500">{{ props.time }}</span>
         </figcaption>

--- a/docs/content/components/letter-up.md
+++ b/docs/content/components/letter-up.md
@@ -34,7 +34,7 @@ const pullupVariant = {
 };
 
 const className = cn(
-  "font-sans text-center text-4xl font-bold tracking-[-0.02em] text-black drop-shadow-sm md:text-4xl md:leading-[5rem]",
+  "font-sans text-center text-4xl font-bold tracking-[-0.02em] text-black dark:text-white drop-shadow-sm md:text-4xl md:leading-[5rem]",
   props.class,
 );
 </script>

--- a/docs/content/components/resizable-navbar.md
+++ b/docs/content/components/resizable-navbar.md
@@ -115,7 +115,7 @@ const isRouterLink = computed(() => props.to !== undefined);
 <template>
   <a
     href="/"
-    class="relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal text-black"
+    class="relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal text-black dark:text-white"
   >
     <img src="https://ui.selemon.dev/icon.png" alt="logo" width="30" height="30" />
     <span class="font-medium text-black dark:text-white">Spark UI</span>

--- a/docs/content/components/skewed-infinite-scroll.md
+++ b/docs/content/components/skewed-infinite-scroll.md
@@ -52,7 +52,7 @@ const props = defineProps<{
               />
               <path d="m9 12 2 2 4-4" />
             </svg>
-            <p class="text-gray-600">
+            <p class="text-gray-600 dark:text-gray-300">
               {{ item.text }}
             </p>
           </div>

--- a/docs/src/components/spark-ui/animated-list/notification.vue
+++ b/docs/src/components/spark-ui/animated-list/notification.vue
@@ -32,7 +32,7 @@ const className = cn(
       </div>
       <div class="flex flex-col overflow-hidden">
         <figcaption class="flex flex-row items-center whitespace-pre text-lg font-medium">
-          <span class="text-sm text-black sm:text-lg">{{ props.name }}</span>
+          <span class="text-sm text-black dark:text-white sm:text-lg">{{ props.name }}</span>
           <span class="mx-1">·</span>
           <span class="text-xs text-gray-500">{{ props.time }}</span>
         </figcaption>

--- a/docs/src/components/spark-ui/letter-up/letter-up.vue
+++ b/docs/src/components/spark-ui/letter-up/letter-up.vue
@@ -23,7 +23,7 @@ const pullupVariant = {
 };
 
 const className = cn(
-  "font-display text-center text-4xl font-bold tracking-[-0.02em] text-black drop-shadow-sm md:text-4xl md:leading-[5rem]",
+  "font-display text-center text-4xl font-bold tracking-[-0.02em] text-black dark:text-white drop-shadow-sm md:text-4xl md:leading-[5rem]",
   props.class,
 );
 </script>

--- a/docs/src/components/spark-ui/skewed-infinite-scroll/skewed-infinite-scroll.vue
+++ b/docs/src/components/spark-ui/skewed-infinite-scroll/skewed-infinite-scroll.vue
@@ -42,7 +42,7 @@ const props = defineProps<{
                 />
                 <path d="m9 12 2 2 4-4" />
               </svg>
-              <p class="text-gray-600">
+              <p class="text-gray-600 dark:text-gray-300">
                 {{ item.text }}
               </p>
             </div>

--- a/docs/src/example/letter-up/letter-up.vue
+++ b/docs/src/example/letter-up/letter-up.vue
@@ -23,7 +23,7 @@ const pullupVariant = {
 };
 
 const className = cn(
-  "font-display text-center text-4xl font-bold tracking-[-0.02em] text-black drop-shadow-sm md:text-4xl md:leading-[5rem]",
+  "font-display text-center text-4xl font-bold tracking-[-0.02em] text-black dark:text-white drop-shadow-sm md:text-4xl md:leading-[5rem]",
   props.class,
 );
 </script>

--- a/docs/src/example/resizable-navbar/navbar-logo.vue
+++ b/docs/src/example/resizable-navbar/navbar-logo.vue
@@ -3,7 +3,7 @@
 <template>
   <a
     href="/"
-    class="relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal text-black"
+    class="relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal text-black dark:text-white"
   >
     <img src="https://ui.selemon.dev/icon.png" alt="logo" width="30" height="30" />
     <span class="font-medium text-black dark:text-white">Spark UI</span>

--- a/docs/src/example/skewed-infinite-scroll/skewed-infinite-scroll.vue
+++ b/docs/src/example/skewed-infinite-scroll/skewed-infinite-scroll.vue
@@ -49,7 +49,7 @@ const currentTheme = computed(() => (isDark.value ? "#1f2937" : "#f3f4f6"));
                 />
                 <path d="m9 12 2 2 4-4" />
               </svg>
-              <p class="text-gray-600">
+              <p class="text-gray-600 dark:text-gray-300">
                 {{ item.text }}
               </p>
             </div>

--- a/docs/src/example/typing-animation/demo.vue
+++ b/docs/src/example/typing-animation/demo.vue
@@ -3,5 +3,5 @@ import TypingAnimation from "./typing-animation.vue";
 </script>
 
 <template>
-  <TypingAnimation class="text-4xl font-bold text-black" text="Typing Animation" />
+  <TypingAnimation class="text-4xl font-bold text-black dark:text-white" text="Typing Animation" />
 </template>

--- a/docs/src/spark-ui-demos/gradual-spacing/gradual-spacing.vue
+++ b/docs/src/spark-ui-demos/gradual-spacing/gradual-spacing.vue
@@ -5,7 +5,7 @@ import GradualSpacing from "../../components/spark-ui/gradual-spacing/gradual-sp
 <template>
   <div class="grid place-items-center w-full min-h-screen">
     <GradualSpacing
-      class="font-sans text-center text-4xl font-bold tracking-[-0.1em] text-black md:text-7xl md:leading-[5rem]"
+      class="font-sans text-center text-4xl font-bold tracking-[-0.1em] text-black dark:text-white md:text-7xl md:leading-[5rem]"
       text="Gradual Spacing"
     />
   </div>

--- a/docs/src/spark-ui-demos/resizable-navbar/navbar-logo.vue
+++ b/docs/src/spark-ui-demos/resizable-navbar/navbar-logo.vue
@@ -3,7 +3,7 @@
 <template>
   <a
     href="/"
-    class="relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal text-black"
+    class="relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal text-black dark:text-white"
   >
     <img src="https://assets.aceternity.com/logo-dark.png" alt="logo" width="30" height="30" />
     <span class="font-medium text-black">Spark UI</span>

--- a/docs/src/spark-ui-demos/typing-animation/typing-animation.vue
+++ b/docs/src/spark-ui-demos/typing-animation/typing-animation.vue
@@ -4,6 +4,6 @@ import TypingAnimation from "../../components/spark-ui/typing-animation/typing-a
 
 <template>
   <div class="grid place-items-center min-h-screen w-full">
-    <TypingAnimation class="text-4xl font-bold text-black" text="Typing Animation" />
+    <TypingAnimation class="text-4xl font-bold text-black dark:text-white" text="Typing Animation" />
   </div>
 </template>


### PR DESCRIPTION
The docs run in light and dark mode, but several component demos hardcoded black/dark text that becomes unreadable in dark mode. Found via two automated sweeps:
1. Static scan for `text-black`/`text-gray-9xx` classes without a `dark:` pair
2. Headless-browser computed-style check in dark mode across all 50 component pages (flags any dark text on a dark background inside the demo cards)

## Fixed (component + demo + docs snippet kept in sync)
- **Animated List** notification title — `text-black` → `text-black dark:text-white`
- **Typing Animation** demo — same
- **Gradual Spacing** display source — same
- **Letter Up** — same
- **Resizable Navbar** logo text — same
- **Skewed Infinite Scroll** card text — `text-gray-600` → `+ dark:text-gray-300`

After the fixes the dark-mode computed-style sweep reports zero dark-on-dark text across all component pages.