### PR TITLE
feat(kinetic-text): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,7 @@ const newComponents = [
 	{ text: "Comic Text", link: "/content/components/comic-text.md" },
 	{ text: "Dotted Map", link: "/content/components/dotted-map.md" },
 	{ text: "Hexagon Pattern", link: "/content/components/hexagon-pattern.md" },
+	{ text: "Kinetic Text", link: "/content/components/kinetic-text.md" },
 ];
 
 const components = [

--- a/docs/content/components/kinetic-text.md
+++ b/docs/content/components/kinetic-text.md
@@ -1,0 +1,125 @@
+# Kinetic Text
+
+A text component that animates the font weight of characters on hover.
+
+<demo src="../../src/example/kinetic-text/demo.vue" srcCode="../../src/spark-ui-demos/kinetic-text/kinetic-text.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [kinetic-text.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+type As = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+
+interface KineticTextProps {
+  text: string;
+  as?: As;
+  class?: string;
+  style?: string | Record<string, string>;
+}
+
+const props = withDefaults(defineProps<KineticTextProps>(), {
+  as: "h1",
+});
+
+const letters = computed(() =>
+  props.text.split("").map((letter) => (letter === " " ? " " : letter)),
+);
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    :class="cn('kinetic-text flex flex-wrap font-[300]', props.class)"
+    :style="props.style"
+  >
+    <span
+      v-for="(letter, i) in letters"
+      :key="i"
+      aria-hidden="true"
+      class="kinetic-text__char"
+      >{{ letter }}</span
+    >
+    <span class="sr-only">{{ props.text }}</span>
+  </component>
+</template>
+
+<style scoped>
+.kinetic-text {
+  --hover-padding: calc(1em / 12);
+  --text-stroke-width: calc(1em * 125 / 6000);
+}
+
+.kinetic-text__char {
+  will-change: font-weight, -webkit-text-stroke-width, padding;
+  -webkit-text-stroke-color: transparent;
+  -webkit-text-stroke-width: var(--text-stroke-width);
+  transition:
+    font-weight 0.4s,
+    -webkit-text-stroke-color 0.4s,
+    padding 0.4s;
+}
+
+/* Hovered character: heaviest weight + visible stroke + padding */
+.kinetic-text__char:hover {
+  padding-inline: var(--hover-padding);
+  font-weight: 900;
+  -webkit-text-stroke-color: currentColor;
+  -webkit-text-stroke-width: calc(var(--text-stroke-width) * 2);
+}
+
+/* The character immediately after the hovered one */
+.kinetic-text__char:hover + .kinetic-text__char {
+  padding-inline: var(--hover-padding);
+  font-weight: 600;
+}
+
+/* The character two positions after the hovered one */
+.kinetic-text__char:hover + .kinetic-text__char + .kinetic-text__char {
+  font-weight: 400;
+}
+
+/* The character immediately before the hovered one */
+.kinetic-text__char:has(+ .kinetic-text__char:hover) {
+  padding-inline: var(--hover-padding);
+  font-weight: 600;
+}
+
+/* The character two positions before the hovered one */
+.kinetic-text__char:has(+ .kinetic-text__char + .kinetic-text__char:hover) {
+  font-weight: 400;
+}
+</style>
+```
+
+:::
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import KineticText from "@/components/ui/kinetic-text.vue";
+</script>
+
+<template>
+  <KineticText text="some text" />
+</template>
+```
+
+## Props
+
+| Prop    | Type                                                            | Default | Description                                         |
+| ------- | -------------------------------------------------------------- | ------- | --------------------------------------------------- |
+| `text`  | `string`                                                        | `-`     | The text content to render with the kinetic effect. |
+| `as`    | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "span"` | `"h1"`  | The HTML element to render as.                      |
+| `class` | `string`                                                        | `-`     | Additional class names for the wrapper element.     |
+
+## Credits
+
+- Credit to [@abdmjd1](https://github.com/abdmjd1)

--- a/docs/src/components/spark-ui/kinetic-text/kinetic-text.vue
+++ b/docs/src/components/spark-ui/kinetic-text/kinetic-text.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "../../../lib/utils";
+
+type As = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+
+interface KineticTextProps {
+  text: string;
+  as?: As;
+  class?: string;
+  style?: string | Record<string, string>;
+}
+
+const props = withDefaults(defineProps<KineticTextProps>(), {
+  as: "h1",
+});
+
+const letters = computed(() =>
+  props.text.split("").map((letter) => (letter === " " ? " " : letter)),
+);
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    :class="cn('kinetic-text flex flex-wrap font-[300]', props.class)"
+    :style="props.style"
+  >
+    <span
+      v-for="(letter, i) in letters"
+      :key="i"
+      aria-hidden="true"
+      class="kinetic-text__char"
+      >{{ letter }}</span
+    >
+    <span class="sr-only">{{ props.text }}</span>
+  </component>
+</template>
+
+<style scoped>
+.kinetic-text {
+  --hover-padding: calc(1em / 12);
+  --text-stroke-width: calc(1em * 125 / 6000);
+}
+
+.kinetic-text__char {
+  will-change: font-weight, -webkit-text-stroke-width, padding;
+  -webkit-text-stroke-color: transparent;
+  -webkit-text-stroke-width: var(--text-stroke-width);
+  transition:
+    font-weight 0.4s,
+    -webkit-text-stroke-color 0.4s,
+    padding 0.4s;
+}
+
+/* Hovered character: heaviest weight + visible stroke + padding */
+.kinetic-text__char:hover {
+  padding-inline: var(--hover-padding);
+  font-weight: 900;
+  -webkit-text-stroke-color: currentColor;
+  -webkit-text-stroke-width: calc(var(--text-stroke-width) * 2);
+}
+
+/* The character immediately after the hovered one */
+.kinetic-text__char:hover + .kinetic-text__char {
+  padding-inline: var(--hover-padding);
+  font-weight: 600;
+}
+
+/* The character two positions after the hovered one */
+.kinetic-text__char:hover + .kinetic-text__char + .kinetic-text__char {
+  font-weight: 400;
+}
+
+/* The character immediately before the hovered one */
+.kinetic-text__char:has(+ .kinetic-text__char:hover) {
+  padding-inline: var(--hover-padding);
+  font-weight: 600;
+}
+
+/* The character two positions before the hovered one */
+.kinetic-text__char:has(+ .kinetic-text__char + .kinetic-text__char:hover) {
+  font-weight: 400;
+}
+</style>

--- a/docs/src/example/kinetic-text/demo.vue
+++ b/docs/src/example/kinetic-text/demo.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import KineticText from "./kinetic-text.vue";
+</script>
+
+<template>
+  <div class="flex w-[300px] justify-center md:w-[500px]">
+    <KineticText
+      text="Nostalgia"
+      class="text-black dark:text-white text-[3rem] md:text-[5rem] tracking-[-0.05em] [font-optical-sizing:auto]"
+    />
+  </div>
+</template>

--- a/docs/src/example/kinetic-text/kinetic-text.vue
+++ b/docs/src/example/kinetic-text/kinetic-text.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "../../lib/utils";
+
+type As = "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+
+interface KineticTextProps {
+  text: string;
+  as?: As;
+  class?: string;
+  style?: string | Record<string, string>;
+}
+
+const props = withDefaults(defineProps<KineticTextProps>(), {
+  as: "h1",
+});
+
+const letters = computed(() =>
+  props.text.split("").map((letter) => (letter === " " ? " " : letter)),
+);
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    :class="cn('kinetic-text flex flex-wrap font-[300]', props.class)"
+    :style="props.style"
+  >
+    <span
+      v-for="(letter, i) in letters"
+      :key="i"
+      aria-hidden="true"
+      class="kinetic-text__char"
+      >{{ letter }}</span
+    >
+    <span class="sr-only">{{ props.text }}</span>
+  </component>
+</template>
+
+<style scoped>
+.kinetic-text {
+  --hover-padding: calc(1em / 12);
+  --text-stroke-width: calc(1em * 125 / 6000);
+}
+
+.kinetic-text__char {
+  will-change: font-weight, -webkit-text-stroke-width, padding;
+  -webkit-text-stroke-color: transparent;
+  -webkit-text-stroke-width: var(--text-stroke-width);
+  transition:
+    font-weight 0.4s,
+    -webkit-text-stroke-color 0.4s,
+    padding 0.4s;
+}
+
+/* Hovered character: heaviest weight + visible stroke + padding */
+.kinetic-text__char:hover {
+  padding-inline: var(--hover-padding);
+  font-weight: 900;
+  -webkit-text-stroke-color: currentColor;
+  -webkit-text-stroke-width: calc(var(--text-stroke-width) * 2);
+}
+
+/* The character immediately after the hovered one */
+.kinetic-text__char:hover + .kinetic-text__char {
+  padding-inline: var(--hover-padding);
+  font-weight: 600;
+}
+
+/* The character two positions after the hovered one */
+.kinetic-text__char:hover + .kinetic-text__char + .kinetic-text__char {
+  font-weight: 400;
+}
+
+/* The character immediately before the hovered one */
+.kinetic-text__char:has(+ .kinetic-text__char:hover) {
+  padding-inline: var(--hover-padding);
+  font-weight: 600;
+}
+
+/* The character two positions before the hovered one */
+.kinetic-text__char:has(+ .kinetic-text__char + .kinetic-text__char:hover) {
+  font-weight: 400;
+}
+</style>

--- a/docs/src/spark-ui-demos/kinetic-text/kinetic-text.vue
+++ b/docs/src/spark-ui-demos/kinetic-text/kinetic-text.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import KineticText from "../../components/spark-ui/kinetic-text/kinetic-text.vue";
+</script>
+
+<template>
+  <div class="flex w-[300px] justify-center md:w-[500px]">
+    <KineticText
+      text="Nostalgia"
+      class="text-black dark:text-white text-[3rem] md:text-[5rem] tracking-[-0.05em] [font-optical-sizing:auto]"
+    />
+  </div>
+</template>

--- a/tests/kinetic-text/kinetic-text.spec.ts
+++ b/tests/kinetic-text/kinetic-text.spec.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import KineticText from "../../docs/src/components/spark-ui/kinetic-text/kinetic-text.vue";
+
+it("renders one span per character plus an sr-only copy", () => {
+  const wrapper = mount(KineticText, { props: { text: "abc" } });
+  const chars = wrapper.findAll(".kinetic-text__char");
+  expect(chars).toHaveLength(3);
+  expect(chars.map((c) => c.text()).join("")).toBe("abc");
+  expect(wrapper.find(".sr-only").text()).toBe("abc");
+});
+
+it("renders as an h1 by default", () => {
+  const wrapper = mount(KineticText, { props: { text: "hi" } });
+  expect(wrapper.element.tagName).toBe("H1");
+});
+
+it("respects the `as` prop", () => {
+  const wrapper = mount(KineticText, { props: { text: "hi", as: "span" } });
+  expect(wrapper.element.tagName).toBe("SPAN");
+});
+
+it("renders spaces as non-breaking spaces", () => {
+  const wrapper = mount(KineticText, { props: { text: "a b" } });
+  const chars = wrapper.findAll(".kinetic-text__char");
+  expect(chars).toHaveLength(3);
+  expect(chars[1]!.element.textContent).toBe("\u00A0");
+});
+
+it("marks per-character spans as aria-hidden", () => {
+  const wrapper = mount(KineticText, { props: { text: "x" } });
+  expect(wrapper.find(".kinetic-text__char").attributes("aria-hidden")).toBe(
+    "true",
+  );
+});
+
+it("merges a custom class onto the wrapper", () => {
+  const wrapper = mount(KineticText, {
+    props: { text: "x", class: "my-custom text-[5rem]" },
+  });
+  expect(wrapper.classes()).toContain("my-custom");
+  expect(wrapper.classes()).toContain("kinetic-text");
+});


### PR DESCRIPTION
Ports Magic UI's **Kinetic Text** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/kinetic-text/kinetic-text.vue` — per-character font-weight ripple on hover; upstream's `has-[...]`/sibling Tailwind selectors translated to a scoped `<style>` block with identical transitions; props `text`, `as` (h1–h6/p/span), `class`, `style`; `sr-only` accessible copy and nbsp space handling preserved
- Theme-aware (`text-black dark:text-white`), pure CSS (no motion library needed — upstream is CSS-only too)
- Live demo, copy-paste source, docs page, one-line sidebar entry, 6 passing tests

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (6)
- Browser check ✅ — hover ripple captured across frames, light + dark, zero overflow, dark-text sweep clean