### PR TITLE
feat(lens): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,6 +48,7 @@ const components = [
 	{ text: "Particles", link: "/content/components/particles.md" },
 	{ text: "Retro Grid", link: "/content/components/retro-grid.md" },
 	{ text: "Ripple", link: "/content/components/ripple.md" },
+	{ text: "Lens", link: "/content/components/lens.md" },
 	{
 		text: "Skewed Infinite Scroll",
 		link: "/content/components/skewed-infinite-scroll.md",

--- a/docs/content/components/lens.md
+++ b/docs/content/components/lens.md
@@ -1,0 +1,197 @@
+# Lens
+
+An interactive component that enables zooming into images, videos and other elements with a magnifying lens.
+
+<demo src="../../src/example/lens/demo.vue" srcCode="../../src/spark-ui-demos/lens/demo.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [lens.vue]
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { cn } from "@/lib/utils";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface LensProps {
+  class?: string;
+  zoomFactor?: number;
+  lensSize?: number;
+  position?: Position;
+  defaultPosition?: Position;
+  isStatic?: boolean;
+  duration?: number;
+  lensColor?: string;
+  ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<LensProps>(), {
+  zoomFactor: 1.3,
+  lensSize: 170,
+  position: () => ({ x: 0, y: 0 }),
+  isStatic: false,
+  duration: 0.1,
+  lensColor: "black",
+  ariaLabel: "Zoom Area",
+});
+
+if (props.zoomFactor < 1) {
+  throw new Error("zoomFactor must be greater than 1");
+}
+if (props.lensSize < 0) {
+  throw new Error("lensSize must be greater than 0");
+}
+
+const isHovering = ref(false);
+const mousePosition = ref<Position>({ ...props.position });
+
+const currentPosition = computed<Position>(() => {
+  if (props.isStatic) return props.position;
+  if (props.defaultPosition && !isHovering.value) return props.defaultPosition;
+  return mousePosition.value;
+});
+
+const maskImage = computed(
+  () =>
+    `radial-gradient(circle ${props.lensSize / 2}px at ${currentPosition.value.x}px ${currentPosition.value.y}px, ${props.lensColor} 100%, transparent 100%)`,
+);
+
+const lensContentStyle = computed(() => ({
+  maskImage: maskImage.value,
+  WebkitMaskImage: maskImage.value,
+  transformOrigin: `${currentPosition.value.x}px ${currentPosition.value.y}px`,
+  zIndex: 50,
+  "--lens-duration": `${props.duration}s`,
+}));
+
+const zoomStyle = computed(() => ({
+  transform: `scale(${props.zoomFactor})`,
+  transformOrigin: `${currentPosition.value.x}px ${currentPosition.value.y}px`,
+}));
+
+function handleMouseMove(e: MouseEvent) {
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  mousePosition.value = {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top,
+  };
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape") isHovering.value = false;
+}
+
+const showStatic = computed(() => props.isStatic || Boolean(props.defaultPosition));
+</script>
+
+<template>
+  <div
+    :class="cn('relative z-20 overflow-hidden rounded-xl', props.class)"
+    role="region"
+    :aria-label="props.ariaLabel"
+    :tabindex="0"
+    @mouseenter="isHovering = true"
+    @mouseleave="isHovering = false"
+    @mousemove="handleMouseMove"
+    @keydown="handleKeyDown"
+  >
+    <slot />
+
+    <div
+      v-if="showStatic"
+      class="absolute inset-0 overflow-hidden"
+      :style="lensContentStyle"
+    >
+      <div class="absolute inset-0" :style="zoomStyle">
+        <slot />
+      </div>
+    </div>
+
+    <Transition v-else name="lens">
+      <div
+        v-if="isHovering"
+        class="absolute inset-0 overflow-hidden"
+        :style="lensContentStyle"
+      >
+        <div class="absolute inset-0" :style="zoomStyle">
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.lens-enter-active,
+.lens-leave-active {
+  transition:
+    opacity var(--lens-duration, 0.1s) ease,
+    transform var(--lens-duration, 0.1s) ease;
+}
+.lens-enter-from {
+  opacity: 0;
+  transform: scale(0.58);
+}
+.lens-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
+}
+</style>
+```
+
+:::
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import Lens from "@/components/spark-ui/lens/lens.vue";
+</script>
+
+<template>
+  <Lens>
+    <img src="/images/lens-demo.jpg" alt="Lens Demo" />
+  </Lens>
+</template>
+```
+
+## Examples
+
+### Static Lens
+
+Set `is-static` with a fixed `position` to render the lens in place without following the cursor.
+
+<demo src="../../src/example/lens/static-demo.vue" srcCode="../../src/spark-ui-demos/lens/static-demo.vue" />
+
+### Lens with a Default Position
+
+Provide a `default-position` so the lens starts in a given spot and follows the cursor on hover.
+
+<demo src="../../src/example/lens/default-position-demo.vue" srcCode="../../src/spark-ui-demos/lens/default-position-demo.vue" />
+
+## Props
+
+| Prop              | Type       | Default          | Description                                                    |
+| ----------------- | ---------- | ---------------- | -------------------------------------------------------------- |
+| `zoomFactor`      | `number`   | `1.3`            | The magnification factor of the lens (must be greater than 1). |
+| `lensSize`        | `number`   | `170`            | The size of the lens in pixels (works as a diameter).          |
+| `position`        | `Position` | `{ x: 0, y: 0 }` | The current position of the lens (used with `isStatic`).       |
+| `defaultPosition` | `Position` | `undefined`      | The initial position of the lens before hovering.              |
+| `isStatic`        | `boolean`  | `false`          | Determines if the lens remains in a fixed position.            |
+| `duration`        | `number`   | `0.1`            | Duration of the fade animation when the lens appears (seconds).|
+| `lensColor`       | `string`   | `"black"`        | The color of the lens mask (CSS color value).                  |
+| `ariaLabel`       | `string`   | `"Zoom Area"`    | Accessibility label for the lens region.                       |
+| `class`           | `string`   | `undefined`      | Additional classes merged onto the container.                  |
+
+## Slots
+
+| Slot      | Description                                        |
+| --------- | -------------------------------------------------- |
+| `default` | The content that will be magnified by the lens.    |

--- a/docs/src/components/spark-ui/lens/lens.vue
+++ b/docs/src/components/spark-ui/lens/lens.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface LensProps {
+  class?: string;
+  zoomFactor?: number;
+  lensSize?: number;
+  position?: Position;
+  defaultPosition?: Position;
+  isStatic?: boolean;
+  duration?: number;
+  lensColor?: string;
+  ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<LensProps>(), {
+  zoomFactor: 1.3,
+  lensSize: 170,
+  position: () => ({ x: 0, y: 0 }),
+  isStatic: false,
+  duration: 0.1,
+  lensColor: "black",
+  ariaLabel: "Zoom Area",
+});
+
+if (props.zoomFactor < 1) {
+  throw new Error("zoomFactor must be greater than 1");
+}
+if (props.lensSize < 0) {
+  throw new Error("lensSize must be greater than 0");
+}
+
+const isHovering = ref(false);
+const mousePosition = ref<Position>({ ...props.position });
+
+const currentPosition = computed<Position>(() => {
+  if (props.isStatic) return props.position;
+  if (props.defaultPosition && !isHovering.value) return props.defaultPosition;
+  return mousePosition.value;
+});
+
+const maskImage = computed(
+  () =>
+    `radial-gradient(circle ${props.lensSize / 2}px at ${currentPosition.value.x}px ${currentPosition.value.y}px, ${props.lensColor} 100%, transparent 100%)`,
+);
+
+const lensContentStyle = computed(() => ({
+  maskImage: maskImage.value,
+  WebkitMaskImage: maskImage.value,
+  transformOrigin: `${currentPosition.value.x}px ${currentPosition.value.y}px`,
+  zIndex: 50,
+  "--lens-duration": `${props.duration}s`,
+}));
+
+const zoomStyle = computed(() => ({
+  transform: `scale(${props.zoomFactor})`,
+  transformOrigin: `${currentPosition.value.x}px ${currentPosition.value.y}px`,
+}));
+
+function handleMouseMove(e: MouseEvent) {
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  mousePosition.value = {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top,
+  };
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape") isHovering.value = false;
+}
+
+const showStatic = computed(() => props.isStatic || Boolean(props.defaultPosition));
+</script>
+
+<template>
+  <div
+    :class="cn('relative z-20 overflow-hidden rounded-xl', props.class)"
+    role="region"
+    :aria-label="props.ariaLabel"
+    :tabindex="0"
+    @mouseenter="isHovering = true"
+    @mouseleave="isHovering = false"
+    @mousemove="handleMouseMove"
+    @keydown="handleKeyDown"
+  >
+    <slot />
+
+    <div
+      v-if="showStatic"
+      class="absolute inset-0 overflow-hidden"
+      :style="lensContentStyle"
+    >
+      <div class="absolute inset-0" :style="zoomStyle">
+        <slot />
+      </div>
+    </div>
+
+    <Transition v-else name="lens">
+      <div
+        v-if="isHovering"
+        class="absolute inset-0 overflow-hidden"
+        :style="lensContentStyle"
+      >
+        <div class="absolute inset-0" :style="zoomStyle">
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.lens-enter-active,
+.lens-leave-active {
+  transition:
+    opacity var(--lens-duration, 0.1s) ease,
+    transform var(--lens-duration, 0.1s) ease;
+}
+.lens-enter-from {
+  opacity: 0;
+  transform: scale(0.58);
+}
+.lens-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
+}
+</style>

--- a/docs/src/example/lens/default-position-demo.vue
+++ b/docs/src/example/lens/default-position-demo.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Lens from "./lens.vue";
+
+const image =
+  "https://images.unsplash.com/photo-1736606355698-5efdb410fe93?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+</script>
+
+<template>
+  <div
+    class="relative w-[300px] md:w-[420px] overflow-hidden rounded-xl border border-black/10 bg-white text-black shadow-sm dark:border-white/10 dark:bg-neutral-950 dark:text-white"
+  >
+    <div class="p-4">
+      <Lens :default-position="{ x: 220, y: 150 }">
+        <img :src="image" alt="image placeholder" width="500" height="500" class="h-40 w-full object-cover" />
+      </Lens>
+    </div>
+    <div class="px-6 pb-2">
+      <h3 class="text-2xl font-semibold">Your next camp</h3>
+      <p class="text-sm text-black/60 dark:text-white/60">
+        See our latest and best camp destinations all across the five continents of the globe.
+      </p>
+    </div>
+    <div class="flex space-x-4 px-6 pb-6 pt-2">
+      <button
+        class="rounded-md bg-black px-4 py-2 text-sm font-medium text-white dark:bg-white dark:text-black"
+      >
+        Let's go
+      </button>
+      <button
+        class="rounded-md bg-black/10 px-4 py-2 text-sm font-medium text-black dark:bg-white/10 dark:text-white"
+      >
+        Another time
+      </button>
+    </div>
+  </div>
+</template>

--- a/docs/src/example/lens/demo.vue
+++ b/docs/src/example/lens/demo.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Lens from "./lens.vue";
+
+const image =
+  "https://images.unsplash.com/photo-1736606355698-5efdb410fe93?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+</script>
+
+<template>
+  <div
+    class="relative w-[300px] md:w-[420px] overflow-hidden rounded-xl border border-black/10 bg-white text-black shadow-sm dark:border-white/10 dark:bg-neutral-950 dark:text-white"
+  >
+    <div class="p-4">
+      <Lens :zoom-factor="2" :lens-size="150" :is-static="false" aria-label="Zoom Area">
+        <img :src="image" alt="image placeholder" width="500" height="500" class="h-40 w-full object-cover" />
+      </Lens>
+    </div>
+    <div class="px-6 pb-2">
+      <h3 class="text-2xl font-semibold">Your next camp</h3>
+      <p class="text-sm text-black/60 dark:text-white/60">
+        See our latest and best camp destinations all across the five continents of the globe.
+      </p>
+    </div>
+    <div class="flex space-x-4 px-6 pb-6 pt-2">
+      <button
+        class="rounded-md bg-black px-4 py-2 text-sm font-medium text-white dark:bg-white dark:text-black"
+      >
+        Let's go
+      </button>
+      <button
+        class="rounded-md bg-black/10 px-4 py-2 text-sm font-medium text-black dark:bg-white/10 dark:text-white"
+      >
+        Another time
+      </button>
+    </div>
+  </div>
+</template>

--- a/docs/src/example/lens/lens.vue
+++ b/docs/src/example/lens/lens.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { cn } from "../../lib/utils";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface LensProps {
+  class?: string;
+  zoomFactor?: number;
+  lensSize?: number;
+  position?: Position;
+  defaultPosition?: Position;
+  isStatic?: boolean;
+  duration?: number;
+  lensColor?: string;
+  ariaLabel?: string;
+}
+
+const props = withDefaults(defineProps<LensProps>(), {
+  zoomFactor: 1.3,
+  lensSize: 170,
+  position: () => ({ x: 0, y: 0 }),
+  isStatic: false,
+  duration: 0.1,
+  lensColor: "black",
+  ariaLabel: "Zoom Area",
+});
+
+if (props.zoomFactor < 1) {
+  throw new Error("zoomFactor must be greater than 1");
+}
+if (props.lensSize < 0) {
+  throw new Error("lensSize must be greater than 0");
+}
+
+const isHovering = ref(false);
+const mousePosition = ref<Position>({ ...props.position });
+
+const currentPosition = computed<Position>(() => {
+  if (props.isStatic) return props.position;
+  if (props.defaultPosition && !isHovering.value) return props.defaultPosition;
+  return mousePosition.value;
+});
+
+const maskImage = computed(
+  () =>
+    `radial-gradient(circle ${props.lensSize / 2}px at ${currentPosition.value.x}px ${currentPosition.value.y}px, ${props.lensColor} 100%, transparent 100%)`,
+);
+
+const lensContentStyle = computed(() => ({
+  maskImage: maskImage.value,
+  WebkitMaskImage: maskImage.value,
+  transformOrigin: `${currentPosition.value.x}px ${currentPosition.value.y}px`,
+  zIndex: 50,
+  "--lens-duration": `${props.duration}s`,
+}));
+
+const zoomStyle = computed(() => ({
+  transform: `scale(${props.zoomFactor})`,
+  transformOrigin: `${currentPosition.value.x}px ${currentPosition.value.y}px`,
+}));
+
+function handleMouseMove(e: MouseEvent) {
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  mousePosition.value = {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top,
+  };
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape") isHovering.value = false;
+}
+
+const showStatic = computed(() => props.isStatic || Boolean(props.defaultPosition));
+</script>
+
+<template>
+  <div
+    :class="cn('relative z-20 overflow-hidden rounded-xl', props.class)"
+    role="region"
+    :aria-label="props.ariaLabel"
+    :tabindex="0"
+    @mouseenter="isHovering = true"
+    @mouseleave="isHovering = false"
+    @mousemove="handleMouseMove"
+    @keydown="handleKeyDown"
+  >
+    <slot />
+
+    <div
+      v-if="showStatic"
+      class="absolute inset-0 overflow-hidden"
+      :style="lensContentStyle"
+    >
+      <div class="absolute inset-0" :style="zoomStyle">
+        <slot />
+      </div>
+    </div>
+
+    <Transition v-else name="lens">
+      <div
+        v-if="isHovering"
+        class="absolute inset-0 overflow-hidden"
+        :style="lensContentStyle"
+      >
+        <div class="absolute inset-0" :style="zoomStyle">
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<style scoped>
+.lens-enter-active,
+.lens-leave-active {
+  transition:
+    opacity var(--lens-duration, 0.1s) ease,
+    transform var(--lens-duration, 0.1s) ease;
+}
+.lens-enter-from {
+  opacity: 0;
+  transform: scale(0.58);
+}
+.lens-leave-to {
+  opacity: 0;
+  transform: scale(0.8);
+}
+</style>

--- a/docs/src/example/lens/static-demo.vue
+++ b/docs/src/example/lens/static-demo.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Lens from "./lens.vue";
+
+const image =
+  "https://images.unsplash.com/photo-1736606355698-5efdb410fe93?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+</script>
+
+<template>
+  <div
+    class="relative w-[300px] md:w-[420px] overflow-hidden rounded-xl border border-black/10 bg-white text-black shadow-sm dark:border-white/10 dark:bg-neutral-950 dark:text-white"
+  >
+    <div class="p-4">
+      <Lens is-static :position="{ x: 220, y: 150 }">
+        <img :src="image" alt="image placeholder" width="500" height="500" class="h-40 w-full object-cover" />
+      </Lens>
+    </div>
+    <div class="px-6 pb-2">
+      <h3 class="text-2xl font-semibold">Your next camp</h3>
+      <p class="text-sm text-black/60 dark:text-white/60">
+        See our latest and best camp destinations all across the five continents of the globe.
+      </p>
+    </div>
+    <div class="flex space-x-4 px-6 pb-6 pt-2">
+      <button
+        class="rounded-md bg-black px-4 py-2 text-sm font-medium text-white dark:bg-white dark:text-black"
+      >
+        Let's go
+      </button>
+      <button
+        class="rounded-md bg-black/10 px-4 py-2 text-sm font-medium text-black dark:bg-white/10 dark:text-white"
+      >
+        Another time
+      </button>
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/lens/default-position-demo.vue
+++ b/docs/src/spark-ui-demos/lens/default-position-demo.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Lens from "../../components/spark-ui/lens/lens.vue";
+
+const image =
+  "https://images.unsplash.com/photo-1736606355698-5efdb410fe93?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+</script>
+
+<template>
+  <div
+    class="relative w-[300px] md:w-[420px] overflow-hidden rounded-xl border border-black/10 bg-white text-black shadow-sm dark:border-white/10 dark:bg-neutral-950 dark:text-white"
+  >
+    <div class="p-4">
+      <Lens :default-position="{ x: 220, y: 150 }">
+        <img :src="image" alt="image placeholder" width="500" height="500" class="h-40 w-full object-cover" />
+      </Lens>
+    </div>
+    <div class="px-6 pb-2">
+      <h3 class="text-2xl font-semibold">Your next camp</h3>
+      <p class="text-sm text-black/60 dark:text-white/60">
+        See our latest and best camp destinations all across the five continents of the globe.
+      </p>
+    </div>
+    <div class="flex space-x-4 px-6 pb-6 pt-2">
+      <button
+        class="rounded-md bg-black px-4 py-2 text-sm font-medium text-white dark:bg-white dark:text-black"
+      >
+        Let's go
+      </button>
+      <button
+        class="rounded-md bg-black/10 px-4 py-2 text-sm font-medium text-black dark:bg-white/10 dark:text-white"
+      >
+        Another time
+      </button>
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/lens/demo.vue
+++ b/docs/src/spark-ui-demos/lens/demo.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Lens from "../../components/spark-ui/lens/lens.vue";
+
+const image =
+  "https://images.unsplash.com/photo-1736606355698-5efdb410fe93?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+</script>
+
+<template>
+  <div
+    class="relative w-[300px] md:w-[420px] overflow-hidden rounded-xl border border-black/10 bg-white text-black shadow-sm dark:border-white/10 dark:bg-neutral-950 dark:text-white"
+  >
+    <div class="p-4">
+      <Lens :zoom-factor="2" :lens-size="150" :is-static="false" aria-label="Zoom Area">
+        <img :src="image" alt="image placeholder" width="500" height="500" class="h-40 w-full object-cover" />
+      </Lens>
+    </div>
+    <div class="px-6 pb-2">
+      <h3 class="text-2xl font-semibold">Your next camp</h3>
+      <p class="text-sm text-black/60 dark:text-white/60">
+        See our latest and best camp destinations all across the five continents of the globe.
+      </p>
+    </div>
+    <div class="flex space-x-4 px-6 pb-6 pt-2">
+      <button
+        class="rounded-md bg-black px-4 py-2 text-sm font-medium text-white dark:bg-white dark:text-black"
+      >
+        Let's go
+      </button>
+      <button
+        class="rounded-md bg-black/10 px-4 py-2 text-sm font-medium text-black dark:bg-white/10 dark:text-white"
+      >
+        Another time
+      </button>
+    </div>
+  </div>
+</template>

--- a/docs/src/spark-ui-demos/lens/static-demo.vue
+++ b/docs/src/spark-ui-demos/lens/static-demo.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import Lens from "../../components/spark-ui/lens/lens.vue";
+
+const image =
+  "https://images.unsplash.com/photo-1736606355698-5efdb410fe93?q=80&w=2071&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D";
+</script>
+
+<template>
+  <div
+    class="relative w-[300px] md:w-[420px] overflow-hidden rounded-xl border border-black/10 bg-white text-black shadow-sm dark:border-white/10 dark:bg-neutral-950 dark:text-white"
+  >
+    <div class="p-4">
+      <Lens is-static :position="{ x: 220, y: 150 }">
+        <img :src="image" alt="image placeholder" width="500" height="500" class="h-40 w-full object-cover" />
+      </Lens>
+    </div>
+    <div class="px-6 pb-2">
+      <h3 class="text-2xl font-semibold">Your next camp</h3>
+      <p class="text-sm text-black/60 dark:text-white/60">
+        See our latest and best camp destinations all across the five continents of the globe.
+      </p>
+    </div>
+    <div class="flex space-x-4 px-6 pb-6 pt-2">
+      <button
+        class="rounded-md bg-black px-4 py-2 text-sm font-medium text-white dark:bg-white dark:text-black"
+      >
+        Let's go
+      </button>
+      <button
+        class="rounded-md bg-black/10 px-4 py-2 text-sm font-medium text-black dark:bg-white/10 dark:text-white"
+      >
+        Another time
+      </button>
+    </div>
+  </div>
+</template>

--- a/tests/lens/lens.spec.ts
+++ b/tests/lens/lens.spec.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import { expect, it } from "vite-plus/test";
+import Lens from "../../docs/src/components/spark-ui/lens/lens.vue";
+
+const slot = { default: () => "<img src='x' alt='x' />" };
+
+it("renders the base content and container defaults", () => {
+  const wrapper = mount(Lens, { slots: slot });
+  const container = wrapper.get("[role='region']");
+
+  expect(container.attributes("aria-label")).toBe("Zoom Area");
+  expect(container.classes()).toContain("overflow-hidden");
+  // interactive mode: no lens content until hovering
+  expect(container.element.querySelectorAll("div").length).toBe(0);
+});
+
+it("shows the lens content immediately when isStatic", () => {
+  const wrapper = mount(Lens, {
+    props: { isStatic: true, position: { x: 100, y: 50 }, zoomFactor: 2 },
+    slots: slot,
+  });
+  const lens = wrapper.get("[role='region'] > div");
+  const style = lens.attributes("style") ?? "";
+
+  expect(style).toContain("transform-origin: 100px 50px");
+  expect(style).toContain("radial-gradient");
+  const zoom = wrapper.get("[role='region'] > div > div");
+  expect(zoom.attributes("style")).toContain("scale(2)");
+});
+
+it("renders lens content when a defaultPosition is provided", () => {
+  const wrapper = mount(Lens, {
+    props: { defaultPosition: { x: 10, y: 20 } },
+    slots: slot,
+  });
+  const lens = wrapper.get("[role='region'] > div");
+  expect(lens.attributes("style")).toContain("transform-origin: 10px 20px");
+});
+
+it("reveals the lens on mouse enter in interactive mode", async () => {
+  const wrapper = mount(Lens, { props: { class: "custom" }, slots: slot });
+  const container = wrapper.get("[role='region']");
+  expect(container.classes()).toContain("custom");
+
+  await container.trigger("mouseenter");
+  await nextTick();
+  expect(wrapper.find(".absolute.inset-0.overflow-hidden").exists()).toBe(true);
+
+  await container.trigger("mouseleave");
+  await nextTick();
+  expect(wrapper.find(".absolute.inset-0.overflow-hidden").exists()).toBe(false);
+});
+
+it("uses lensColor and lensSize in the mask", () => {
+  const wrapper = mount(Lens, {
+    props: { isStatic: true, position: { x: 0, y: 0 }, lensSize: 200, lensColor: "red" },
+    slots: slot,
+  });
+  const style = wrapper.get("[role='region'] > div").attributes("style") ?? "";
+  expect(style).toContain("circle 100px");
+  expect(style).toContain("red");
+});
+
+it("throws when zoomFactor is less than 1", () => {
+  expect(() => mount(Lens, { props: { zoomFactor: 0.5 }, slots: slot })).toThrow(
+    "zoomFactor must be greater than 1",
+  );
+});


### PR DESCRIPTION
Ports Magic UI's **Lens** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/lens/lens.vue` — magnifier over slot content (slot rendered twice: base + scaled clone inside a radial-gradient mask); full prop parity (`zoomFactor`, `lensSize`, `position`, `defaultPosition`, `isStatic`, `duration`, `lensColor`, `ariaLabel`, `class`), upstream validation and Escape handling preserved; `AnimatePresence` replaced with native Vue `<Transition>`
- 3 demos (hover, static, default-position) with shadcn Card replaced by theme-paired plain markup
- Docs page, one-line sidebar entry, 6 passing tests

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (6)
- Browser check ✅ — magnifier circle visible on hover, light + dark, containment sweep clean