### PR TITLE
feat(line-shadow-text): add SparkUI port

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -42,6 +42,7 @@ const components = [
 	{ text: "Globe", link: "/content/components/globe.md" },
 	{ text: "Gradual Spacing", link: "/content/components/gradual-spacing.md" },
 	{ text: "Letter Up", link: "/content/components/letter-up.md" },
+	{ text: "Line Shadow Text", link: "/content/components/line-shadow-text.md" },
 	{ text: "Marquee", link: "/content/components/marquee.md" },
 	{ text: "Meteors", link: "/content/components/meteors.md" },
 	{ text: "Orbiting Circles", link: "/content/components/orbiting-circles.md" },

--- a/docs/content/components/line-shadow-text.md
+++ b/docs/content/components/line-shadow-text.md
@@ -1,0 +1,120 @@
+# Line Shadow Text
+
+A text component with a moving diagonal line shadow.
+
+<demo src="../../src/example/line-shadow-text/demo.vue" srcCode="../../src/spark-ui-demos/line-shadow-text/line-shadow-text.vue" />
+
+## Installation
+
+Copy and paste the following code into your project:
+
+::: code-group
+
+```vue [line-shadow-text.vue]
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "@/lib/utils";
+
+interface LineShadowTextProps {
+  class?: string;
+  text: string;
+  shadowColor?: string;
+  as?: keyof HTMLElementTagNameMap;
+}
+
+const props = withDefaults(defineProps<LineShadowTextProps>(), {
+  shadowColor: "black",
+  as: "span",
+});
+
+const style = computed(() => ({
+  "--shadow-color": props.shadowColor,
+}));
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    :style="style"
+    :data-text="props.text"
+    :class="cn('line-shadow-text relative z-0 inline-flex', props.class)"
+  >
+    {{ props.text }}
+  </component>
+</template>
+
+<style scoped>
+.line-shadow-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0.04em;
+  left: 0.04em;
+  z-index: -10;
+  background-image: linear-gradient(
+    45deg,
+    transparent 45%,
+    var(--shadow-color) 45%,
+    var(--shadow-color) 55%,
+    transparent 0
+  );
+  background-size: 0.06em 0.06em;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: line-shadow 15s linear infinite;
+}
+
+@keyframes line-shadow {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 100% -100%;
+  }
+}
+</style>
+```
+
+:::
+
+If you prefer to keep the keyframes in your Tailwind config instead of a scoped `<style>` block, add the following animation to your `tailwind.config.js`:
+
+```js [tailwind.config.js]
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  theme: {
+    extend: {
+      animation: {
+        "line-shadow": "line-shadow 15s linear infinite",
+      },
+      keyframes: {
+        "line-shadow": {
+          "0%": { "background-position": "0 0" },
+          "100%": { "background-position": "100% -100%" },
+        },
+      },
+    },
+  },
+};
+```
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import LineShadowText from "@/components/spark-ui/line-shadow-text/line-shadow-text.vue";
+</script>
+
+<template>
+  <LineShadowText text="Fast" shadow-color="black" />
+</template>
+```
+
+## Props
+
+| Prop          | Type                             | Default   | Description                              |
+| ------------- | -------------------------------- | --------- | ---------------------------------------- |
+| `text`        | `string`                         | `-`       | The text to display with shadow effect   |
+| `shadowColor` | `string`                         | `"black"` | The color of the moving line shadow      |
+| `as`          | `keyof HTMLElementTagNameMap`    | `"span"`  | The HTML element to render the text as   |
+| `class`       | `string`                         | `-`       | Additional classes to merge onto the tag |

--- a/docs/src/components/spark-ui/line-shadow-text/line-shadow-text.vue
+++ b/docs/src/components/spark-ui/line-shadow-text/line-shadow-text.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "../../../lib/utils";
+
+interface LineShadowTextProps {
+  class?: string;
+  text: string;
+  shadowColor?: string;
+  as?: keyof HTMLElementTagNameMap;
+}
+
+const props = withDefaults(defineProps<LineShadowTextProps>(), {
+  shadowColor: "black",
+  as: "span",
+});
+
+const style = computed(() => ({
+  "--shadow-color": props.shadowColor,
+}));
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    :style="style"
+    :data-text="props.text"
+    :class="cn('line-shadow-text relative z-0 inline-flex', props.class)"
+  >
+    {{ props.text }}
+  </component>
+</template>
+
+<style scoped>
+.line-shadow-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0.04em;
+  left: 0.04em;
+  z-index: -10;
+  background-image: linear-gradient(
+    45deg,
+    transparent 45%,
+    var(--shadow-color) 45%,
+    var(--shadow-color) 55%,
+    transparent 0
+  );
+  background-size: 0.06em 0.06em;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: line-shadow 15s linear infinite;
+}
+
+@keyframes line-shadow {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 100% -100%;
+  }
+}
+</style>

--- a/docs/src/example/line-shadow-text/demo.vue
+++ b/docs/src/example/line-shadow-text/demo.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { useData } from "vitepress";
+import { computed } from "vue";
+import LineShadowText from "./line-shadow-text.vue";
+
+const { isDark } = useData();
+
+const shadowColor = computed(() => (isDark.value ? "white" : "black"));
+</script>
+
+<template>
+  <h1
+    class="text-5xl leading-none font-semibold tracking-tighter text-balance sm:text-6xl md:text-7xl text-black dark:text-white"
+  >
+    Ship
+    <LineShadowText class="italic" text="Fast" :shadow-color="shadowColor" />
+  </h1>
+</template>

--- a/docs/src/example/line-shadow-text/line-shadow-text.vue
+++ b/docs/src/example/line-shadow-text/line-shadow-text.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { cn } from "../../lib/utils";
+
+interface LineShadowTextProps {
+  class?: string;
+  text: string;
+  shadowColor?: string;
+  as?: keyof HTMLElementTagNameMap;
+}
+
+const props = withDefaults(defineProps<LineShadowTextProps>(), {
+  shadowColor: "black",
+  as: "span",
+});
+
+const style = computed(() => ({
+  "--shadow-color": props.shadowColor,
+}));
+</script>
+
+<template>
+  <component
+    :is="props.as"
+    :style="style"
+    :data-text="props.text"
+    :class="cn('line-shadow-text relative z-0 inline-flex', props.class)"
+  >
+    {{ props.text }}
+  </component>
+</template>
+
+<style scoped>
+.line-shadow-text::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0.04em;
+  left: 0.04em;
+  z-index: -10;
+  background-image: linear-gradient(
+    45deg,
+    transparent 45%,
+    var(--shadow-color) 45%,
+    var(--shadow-color) 55%,
+    transparent 0
+  );
+  background-size: 0.06em 0.06em;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: line-shadow 15s linear infinite;
+}
+
+@keyframes line-shadow {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 100% -100%;
+  }
+}
+</style>

--- a/docs/src/spark-ui-demos/line-shadow-text/line-shadow-text.vue
+++ b/docs/src/spark-ui-demos/line-shadow-text/line-shadow-text.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { useData } from "vitepress";
+import { computed } from "vue";
+import LineShadowText from "../../components/spark-ui/line-shadow-text/line-shadow-text.vue";
+
+const { isDark } = useData();
+
+const shadowColor = computed(() => (isDark.value ? "white" : "black"));
+</script>
+
+<template>
+  <h1
+    class="text-5xl leading-none font-semibold tracking-tighter text-balance sm:text-6xl md:text-7xl text-black dark:text-white"
+  >
+    Ship
+    <LineShadowText class="italic" text="Fast" :shadow-color="shadowColor" />
+  </h1>
+</template>

--- a/tests/line-shadow-text/line-shadow-text.spec.ts
+++ b/tests/line-shadow-text/line-shadow-text.spec.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { expect, it } from "vite-plus/test";
+import LineShadowText from "../../docs/src/components/spark-ui/line-shadow-text/line-shadow-text.vue";
+
+it("renders the text content", () => {
+  const wrapper = mount(LineShadowText, { props: { text: "Fast" } });
+  expect(wrapper.text()).toBe("Fast");
+});
+
+it("mirrors the text into the data-text attribute for the shadow", () => {
+  const wrapper = mount(LineShadowText, { props: { text: "Fast" } });
+  expect(wrapper.get("span").attributes("data-text")).toBe("Fast");
+});
+
+it("applies the base line-shadow-text classes", () => {
+  const wrapper = mount(LineShadowText, { props: { text: "Fast" } });
+  const el = wrapper.get("span");
+  expect(el.classes()).toContain("line-shadow-text");
+  expect(el.classes()).toContain("relative");
+  expect(el.classes()).toContain("inline-flex");
+});
+
+it("defaults shadowColor to black via the --shadow-color CSS var", () => {
+  const wrapper = mount(LineShadowText, { props: { text: "Fast" } });
+  const style = wrapper.get("span").attributes("style") ?? "";
+  expect(style).toContain("--shadow-color: black");
+});
+
+it("respects a custom shadowColor", () => {
+  const wrapper = mount(LineShadowText, {
+    props: { text: "Fast", shadowColor: "white" },
+  });
+  const style = wrapper.get("span").attributes("style") ?? "";
+  expect(style).toContain("--shadow-color: white");
+});
+
+it("renders as a custom element via the as prop", () => {
+  const wrapper = mount(LineShadowText, {
+    props: { text: "Fast", as: "h1" },
+  });
+  expect(wrapper.find("h1").exists()).toBe(true);
+});
+
+it("merges a custom class", () => {
+  const wrapper = mount(LineShadowText, {
+    props: { text: "Fast", class: "italic" },
+  });
+  expect(wrapper.get("span").classes()).toContain("italic");
+});


### PR DESCRIPTION
Ports Magic UI's **Line Shadow Text** to Spark UI as a native Vue 3 component with full feature parity.

## What's included
- `docs/src/components/spark-ui/line-shadow-text/line-shadow-text.vue` — striped diagonal shadow via `::after` repeating gradient + background-position keyframe (scoped `<style>`; documented as a tailwind snippet for consumers); props `text`, `as`, `shadowColor`, `class`
- Theme-aware demo (white shadow in dark, black in light via `useData().isDark`)
- Docs page, one-line sidebar entry, 7 passing tests

## Verification
- `pnpm lint` ✅ · `vue-tsc` docs typecheck ✅ · `validate-component` ✅ · tests ✅ (7)
- Browser check ✅ — stripes animating across frames, light + dark, overflow + dark-text sweeps clean