### PR TITLE
fix: theme-aware text colors in dark mode

### DIFF
--- a/docs/.vitepress/components/demo-block/src/index.vue
+++ b/docs/.vitepress/components/demo-block/src/index.vue
@@ -55,7 +55,7 @@ function handleRefreshComponent() {
 <template>
   <div class="mt-6 relative">
     <div
-      class="relative flex h-[600px] w-full bg-[#fffefe] flex-col items-center justify-center overflow-hidden rounded-lg border-parent dark:border-none bg-background c-#282f38 overflow-x-scroll dark:bg-[#000000] flex-wrap [&:o-button-base]:!c-context vp-raw bg"
+      class="relative flex h-[600px] w-full bg-[#fffefe] flex-col items-center justify-center overflow-hidden rounded-lg border-parent dark:border-none bg-background c-#282f38 dark:c-#e5e5e5 overflow-x-scroll dark:bg-[#000000] flex-wrap [&:o-button-base]:!c-context vp-raw bg"
     >
       <DotPattern
         class="absolute inset-0 size-full"

--- a/docs/src/example/bento-grid/demo.vue
+++ b/docs/src/example/bento-grid/demo.vue
@@ -47,7 +47,7 @@ const features = [
           >
             <Icon
               :icon="feat.icon"
-              class="h-12 w-12 origin-left transform-gpu text-neutral-700 transition-all duration-300 ease-in-out group-hover:scale-75"
+              class="h-12 w-12 origin-left transform-gpu text-neutral-700 dark:text-neutral-300 transition-all duration-300 ease-in-out group-hover:scale-75"
             />
             <h3 class="text-xl font-semibold text-neutral-700 dark:text-neutral-300">
               {{ feat.name }}

--- a/docs/src/example/resizable-navbar/nav-items.vue
+++ b/docs/src/example/resizable-navbar/nav-items.vue
@@ -19,14 +19,14 @@ function handleClick() {
 
 <template>
   <div
-    class="absolute inset-0 hidden flex-1 flex-row items-center justify-center space-x-2 text-sm font-medium text-zinc-600 transition duration-200 hover:text-zinc-800 lg:flex lg:space-x-2"
+    class="absolute inset-0 hidden flex-1 flex-row items-center justify-center space-x-2 text-sm font-medium text-zinc-600 dark:text-zinc-300 transition duration-200 hover:text-zinc-800 dark:hover:text-zinc-100 lg:flex lg:space-x-2"
     :class="className"
   >
     <a
       v-for="(item, idx) in items"
       :key="`link-${idx}`"
       :href="item?.link"
-      class="relative px-4 py-2 text-neutral-600"
+      class="relative px-4 py-2 text-neutral-600 dark:text-neutral-300"
       @mouseenter="handleItemHover(idx)"
       @click="handleClick"
     >

--- a/docs/src/spark-ui-demos/bento-grid/bento-grid.vue
+++ b/docs/src/spark-ui-demos/bento-grid/bento-grid.vue
@@ -47,7 +47,7 @@ const features = [
           >
             <Icon
               :icon="feat.icon"
-              class="h-12 w-12 origin-left transform-gpu text-neutral-700 transition-all duration-300 ease-in-out group-hover:scale-75"
+              class="h-12 w-12 origin-left transform-gpu text-neutral-700 dark:text-neutral-300 transition-all duration-300 ease-in-out group-hover:scale-75"
             />
             <h3 class="text-xl font-semibold text-neutral-700 dark:text-neutral-300">
               {{ feat.name }}

--- a/docs/src/spark-ui-demos/resizable-navbar/demo.vue
+++ b/docs/src/spark-ui-demos/resizable-navbar/demo.vue
@@ -120,7 +120,7 @@ const boxes = [
               v-for="(item, idx) in navItems"
               :key="`mobile-link-${idx}`"
               :href="item.link"
-              class="w-full px-4 py-2 text-neutral-600 hover:bg-gray-100 rounded-md"
+              class="w-full px-4 py-2 text-neutral-600 dark:text-neutral-300 hover:bg-gray-100 dark:hover:bg-neutral-800 rounded-md"
               @click="closeMenu"
             >
               {{ item.name }}
@@ -137,7 +137,7 @@ const boxes = [
       <h1 class="mb-4 text-center text-3xl font-bold">
         Check the navbar at the top of the container
       </h1>
-      <p class="mb-10 text-center text-sm text-zinc-500">
+      <p class="mb-10 text-center text-sm text-zinc-500 dark:text-zinc-400">
         For demo purpose we have kept the position as
         <span class="font-medium">Sticky</span>. Keep in mind that this component is
         <span class="font-medium">fixed</span> and will not move when scrolling.

--- a/docs/src/spark-ui-demos/resizable-navbar/nav-items.vue
+++ b/docs/src/spark-ui-demos/resizable-navbar/nav-items.vue
@@ -23,7 +23,7 @@ function handleClick() {
 
 <template>
   <div
-    class="absolute inset-0 hidden flex-1 flex-row items-center justify-center space-x-2 text-sm font-medium text-zinc-600 transition duration-200 hover:text-zinc-800 lg:flex lg:space-x-2"
+    class="absolute inset-0 hidden flex-1 flex-row items-center justify-center space-x-2 text-sm font-medium text-zinc-600 dark:text-zinc-300 transition duration-200 hover:text-zinc-800 dark:hover:text-zinc-100 lg:flex lg:space-x-2"
     :class="className"
     @mouseleave="clearHover"
   >
@@ -31,7 +31,7 @@ function handleClick() {
       v-for="(item, idx) in items"
       :key="`link-${idx}`"
       :href="item?.link"
-      class="relative px-4 py-2 text-neutral-600"
+      class="relative px-4 py-2 text-neutral-600 dark:text-neutral-300"
       @mouseenter="handleItemHover(idx)"
       @click="handleClick"
     >

--- a/docs/src/spark-ui-demos/resizable-navbar/navbar-logo.vue
+++ b/docs/src/spark-ui-demos/resizable-navbar/navbar-logo.vue
@@ -6,6 +6,6 @@
     class="relative z-20 mr-4 flex items-center space-x-2 px-2 py-1 text-sm font-normal text-black dark:text-white"
   >
     <img src="https://assets.aceternity.com/logo-dark.png" alt="logo" width="30" height="30" />
-    <span class="font-medium text-black">Spark UI</span>
+    <span class="font-medium text-black dark:text-white">Spark UI</span>
   </a>
 </template>


### PR DESCRIPTION
## Summary
- Fix the shared demo-block wrapper's hardcoded `c-#282f38` text color by adding `dark:c-#e5e5e5`, so demo text that inherits the default color (circular progress, animated gradient text, dia-text-reveal, dock, file tree, glare-hover, highlighter, etc.) renders light in dark mode
- Add `dark:` text variants to Bento Grid icon and Resizable Navbar nav items, logo, mobile menu links, and demo description

## Verification
Ran a headless-browser sweep of all 55 component demo pages in dark mode checking computed text colors against backgrounds — all pages clean. Two apparent flags were confirmed false positives (Interactive Hover Button's hidden hover overlay intentionally uses `dark:text-black`; Dotted Map labels render `fill="white"` in SVG).