### PR TITLE
feat: list all components in the navbar dropdown

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -69,6 +69,10 @@ const components = [
 	{ text: "Typing Animation", link: "/content/components/typing-animation.md" },
 ];
 
+const allComponents = [...components, ...newComponents].sort((a, b) =>
+	a.text.localeCompare(b.text),
+);
+
 export default defineConfig({
 	vite: {
 		plugins: [
@@ -123,7 +127,7 @@ export default defineConfig({
 					},
 				],
 			},
-			{ text: "Components", items: components },
+			{ text: "Components", items: allComponents },
 			{ text: "Showcase", link: "" },
 			{ text: `v${version}`, link: "" },
 		],


### PR DESCRIPTION
## Summary
The navbar's **Components** dropdown only listed the 20 original components. It now shows the full catalog — old + new merged and sorted alphabetically — while the sidebar keeps its separate "New Components" and "Components" sections.

## Verification
Full docs build passes; rendered pages' nav markup contains both old (Animated Beam) and new (Line Shadow Text) entries. Cross-checked the merged list against `docs/content/components/`: every page is linked, no duplicates, no dead links.