### PR TITLE
fix(tests): stop hyper-text spec hanging the test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## v1.0.0
 
+[compare changes](https://github.com/selemondev/spark-ui/compare/v1.0.0...v1.0.0)
+
+### 🏡 Chore
+
+- Release latest version ([000bf9f](https://github.com/selemondev/spark-ui/commit/000bf9f))
+
+### ❤️ Contributors
+
+- Selemondev <selemondev19@gmail.com>
+
+## v1.0.0
+
 [compare changes](https://github.com/selemondev/spark-ui/compare/v0.0.2...v1.0.0)
 
 ### 🚀 Enhancements

--- a/tests/hyper-text/hyper-text.spec.ts
+++ b/tests/hyper-text/hyper-text.spec.ts
@@ -29,9 +29,14 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+// Run only the frames queued at call time. Draining newly scheduled frames in
+// the same pass would loop forever, since the component reschedules a frame on
+// every tick until `now` advances past the animation duration.
 const drainRaf = () => {
-  while (rafCallbacks.length) {
-    rafCallbacks.shift()?.(now);
+  const pending = rafCallbacks;
+  rafCallbacks = [];
+  for (const cb of pending) {
+    cb(now);
   }
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   plugins: [Vue()],
   test: {
     clearMocks: true,
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      // Stale agent git worktrees hold duplicated specs that hang the run
+      "**/.claude/worktrees/**",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Problem

Running the test suite (`vp test`) hung indefinitely, pegging a worker at 100% CPU.

Root cause is in `tests/hyper-text/hyper-text.spec.ts`: `drainRaf()` looped `while (rafCallbacks.length)` and invoked every frame at a fixed timestamp. `HyperText` correctly reschedules a `requestAnimationFrame` on every tick while `progress < 1` (`hyper-text.vue:104-105`), so draining at `setNow(0)` (elapsed 0) queued a new frame for each one drained — the loop never emptied. This is a test bug, not a component bug.

Separately, stale `.claude/worktrees/agent-*/` directories held duplicated `.spec.ts` files that Vitest also scanned, running the buggy spec multiple times over and multiplying the hang.

## Fix

- `drainRaf()` now snapshots the currently-queued frames and runs only that generation, so frames scheduled mid-drain wait for the next `now`.
- Added `**/.claude/worktrees/**` to `test.exclude` in `vite.config.ts` so stale agent worktrees are no longer picked up.

## Verification

Full suite now completes cleanly: **30 files, 171 tests passing in ~5.6s** (previously hung forever).