### PR TITLE
chore(ci): drop npm publish steps from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,3 @@ jobs:
 
       - name: Test
         run: nr test
-
-      - name: Config npm
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish to npm
-        run: npm publish --access public --no-git-checks


### PR DESCRIPTION
The project is not published to npm. Removes the `Config npm` and `Publish to npm` steps from `release.yml`; the workflow still runs changelog, install, build, and test.