### PR TITLE
fix(ci): create GitHub release with built-in token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -28,7 +30,7 @@ jobs:
       - run: npx changelogithub
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install
         run: nci


### PR DESCRIPTION
The release workflow never created a GitHub Release (latest stayed at v0.0.2). `changelogithub` was given `secrets.GH_TOKEN`, which is unset — it logged `No GitHub token found ... Release skipped`, and `continue-on-error: true` masked it.

- Use built-in `secrets.GITHUB_TOKEN`.
- Grant the job `contents: write` (needed to create releases; default token was read-only).