### PR TITLE
fix(animated-beam): render on iOS Safari and Chrome

### DIFF
--- a/docs/content/components/animated-beam.md
+++ b/docs/content/components/animated-beam.md
@@ -12,7 +12,7 @@ Copy and paste the following code into your project:
 
 ```vue [animated-beam.vue]
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -55,12 +55,14 @@ const props = withDefaults(
 
 const id = `pattern-${useId()}`;
 
-const initial = {
-  x1: "10%",
-  x2: "0%",
-  y1: "0%",
-  y2: "0%",
-};
+// Keyframe values for the animated gradient. We animate the gradient's own
+// x1/x2 attributes via native SVG (SMIL) `<animate>` elements instead of a CSS
+// transform. WebKit (Safari and Chrome on iOS) does not move an SVG gradient
+// via CSS transforms, which is why the beam was invisible there.
+const gradientCoordinates = computed(() =>
+  props.reverse ? { x1: "90%;-10%", x2: "100%;0%" } : { x1: "10%;110%", x2: "0%;100%" },
+);
+
 const svgDimensions = ref({ width: 0, height: 0 });
 const pathD = ref("");
 function updatePath() {
@@ -139,29 +141,27 @@ watch(
     />
     <path :d="pathD" :stroke="`url(#${id})`" fill="none" stroke-linecap="round" />
     <defs>
-      <linearGradient
-        :id="id"
-        v-motion
-        :initial="{
-          opacity: 0,
-          x: props.reverse ? ['100%', '0%'] : ['0%', '100%'],
-        }"
-        :enter="{
-          opacity: 1,
-          x: props.reverse ? ['100%', '0%'] : ['0%', '100%'],
-          transition: {
-            duration: 1600,
-            type: 'keyframes',
-            easings: [0.16, 1, 0.3, 1],
-            repeat: Infinity,
-          },
-        }"
-        gradientUnits="userSpaceOnUse"
-        :x1="initial.x1"
-        :x2="initial.x2"
-        :y1="initial.y1"
-        :y2="initial.y2"
-      >
+      <linearGradient :id="id" gradientUnits="userSpaceOnUse" x1="0%" x2="0%" y1="0%" y2="0%">
+        <animate
+          attributeName="x1"
+          :values="gradientCoordinates.x1"
+          :dur="`${duration}s`"
+          :begin="`${delay}s`"
+          repeatCount="indefinite"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines="0.16 1 0.3 1"
+        />
+        <animate
+          attributeName="x2"
+          :values="gradientCoordinates.x2"
+          :dur="`${duration}s`"
+          :begin="`${delay}s`"
+          repeatCount="indefinite"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines="0.16 1 0.3 1"
+        />
         <stop :stop-color="props.gradientStartColor" stop-opacity="0" />
         <stop :stop-color="props.gradientStartColor" />
         <stop offset="32.5%" :stop-color="props.gradientStopColor" />

--- a/docs/content/components/animated-beam.md
+++ b/docs/content/components/animated-beam.md
@@ -12,7 +12,7 @@ Copy and paste the following code into your project:
 
 ```vue [animated-beam.vue]
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, useId, watch } from "vue";
+import { nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -86,15 +86,29 @@ function updatePath() {
 }
 
 const controller = new AbortController();
+let resizeObserver: ResizeObserver | null = null;
 
 onMounted(() => {
   window.addEventListener("resize", updatePath, {
     signal: controller.signal,
   });
+
+  // Observe the container so the path is recalculated once its layout settles.
+  // On iOS Safari/Chrome the container's dimensions are often 0 on the first
+  // tick, so relying on the window "resize" event alone leaves the SVG sized
+  // at 0x0 and nothing renders.
+  if (typeof ResizeObserver !== "undefined" && props.containerRef) {
+    resizeObserver = new ResizeObserver(() => updatePath());
+    resizeObserver.observe(props.containerRef);
+  }
+
+  // Compute the initial path once the DOM has been laid out.
+  nextTick(updatePath);
 });
 
 onUnmounted(() => {
   controller.abort();
+  resizeObserver?.disconnect();
 });
 
 watch(
@@ -123,7 +137,7 @@ watch(
       :stroke-opacity="pathOpacity"
       stroke-linecap="round"
     />
-    <path :d="pathD" :stroke="`url(#${id}`" fill="none" stroke-linecap="round" />
+    <path :d="pathD" :stroke="`url(#${id})`" fill="none" stroke-linecap="round" />
     <defs>
       <linearGradient
         :id="id"

--- a/docs/src/components/spark-ui/animated-beam/animated-beam.vue
+++ b/docs/src/components/spark-ui/animated-beam/animated-beam.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -42,12 +42,14 @@ const props = withDefaults(
 
 const id = `pattern-${useId()}`;
 
-const initial = {
-  x1: "10%",
-  x2: "0%",
-  y1: "0%",
-  y2: "0%",
-};
+// Keyframe values for the animated gradient. We animate the gradient's own
+// x1/x2 attributes via native SVG (SMIL) `<animate>` elements instead of a CSS
+// transform. WebKit (Safari and Chrome on iOS) does not move an SVG gradient
+// via CSS transforms, which is why the beam was invisible there.
+const gradientCoordinates = computed(() =>
+  props.reverse ? { x1: "90%;-10%", x2: "100%;0%" } : { x1: "10%;110%", x2: "0%;100%" },
+);
+
 const svgDimensions = ref({ width: 0, height: 0 });
 const pathD = ref("");
 function updatePath() {
@@ -126,29 +128,27 @@ watch(
     />
     <path :d="pathD" :stroke="`url(#${id})`" fill="none" stroke-linecap="round" />
     <defs>
-      <linearGradient
-        :id="id"
-        v-motion
-        :initial="{
-          opacity: 0,
-          x: props.reverse ? ['100%', '0%'] : ['0%', '100%'],
-        }"
-        :enter="{
-          opacity: 1,
-          x: props.reverse ? ['100%', '0%'] : ['0%', '100%'],
-          transition: {
-            duration: 1600,
-            type: 'keyframes',
-            easings: [0.16, 1, 0.3, 1],
-            repeat: Infinity,
-          },
-        }"
-        gradientUnits="userSpaceOnUse"
-        :x1="initial.x1"
-        :x2="initial.x2"
-        :y1="initial.y1"
-        :y2="initial.y2"
-      >
+      <linearGradient :id="id" gradientUnits="userSpaceOnUse" x1="0%" x2="0%" y1="0%" y2="0%">
+        <animate
+          attributeName="x1"
+          :values="gradientCoordinates.x1"
+          :dur="`${duration}s`"
+          :begin="`${delay}s`"
+          repeatCount="indefinite"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines="0.16 1 0.3 1"
+        />
+        <animate
+          attributeName="x2"
+          :values="gradientCoordinates.x2"
+          :dur="`${duration}s`"
+          :begin="`${delay}s`"
+          repeatCount="indefinite"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines="0.16 1 0.3 1"
+        />
         <stop :stop-color="props.gradientStartColor" stop-opacity="0" />
         <stop :stop-color="props.gradientStartColor" />
         <stop offset="32.5%" :stop-color="props.gradientStopColor" />

--- a/docs/src/components/spark-ui/animated-beam/animated-beam.vue
+++ b/docs/src/components/spark-ui/animated-beam/animated-beam.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, useId, watch } from "vue";
+import { nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -73,15 +73,29 @@ function updatePath() {
 }
 
 const controller = new AbortController();
+let resizeObserver: ResizeObserver | null = null;
 
 onMounted(() => {
   window.addEventListener("resize", updatePath, {
     signal: controller.signal,
   });
+
+  // Observe the container so the path is recalculated once its layout settles.
+  // On iOS Safari/Chrome the container's dimensions are often 0 on the first
+  // tick, so relying on the window "resize" event alone leaves the SVG sized
+  // at 0x0 and nothing renders.
+  if (typeof ResizeObserver !== "undefined" && props.containerRef) {
+    resizeObserver = new ResizeObserver(() => updatePath());
+    resizeObserver.observe(props.containerRef);
+  }
+
+  // Compute the initial path once the DOM has been laid out.
+  nextTick(updatePath);
 });
 
 onUnmounted(() => {
   controller.abort();
+  resizeObserver?.disconnect();
 });
 
 watch(
@@ -110,7 +124,7 @@ watch(
       :stroke-opacity="pathOpacity"
       stroke-linecap="round"
     />
-    <path :d="pathD" :stroke="`url(#${id}`" fill="none" stroke-linecap="round" />
+    <path :d="pathD" :stroke="`url(#${id})`" fill="none" stroke-linecap="round" />
     <defs>
       <linearGradient
         :id="id"

--- a/docs/src/example/animated-beam/animated-beam.vue
+++ b/docs/src/example/animated-beam/animated-beam.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, useId, watch } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, useId, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -42,12 +42,14 @@ const props = withDefaults(
 
 const id = `pattern-${useId()}`;
 
-const initial = {
-  x1: "10%",
-  x2: "0%",
-  y1: "0%",
-  y2: "0%",
-};
+// Keyframe values for the animated gradient. We animate the gradient's own
+// x1/x2 attributes via native SVG (SMIL) `<animate>` elements instead of a CSS
+// transform. WebKit (Safari and Chrome on iOS) does not move an SVG gradient
+// via CSS transforms, which is why the beam was invisible there.
+const gradientCoordinates = computed(() =>
+  props.reverse ? { x1: "90%;-10%", x2: "100%;0%" } : { x1: "10%;110%", x2: "0%;100%" },
+);
+
 const svgDimensions = ref({ width: 0, height: 0 });
 const pathD = ref("");
 function updatePath() {
@@ -73,15 +75,29 @@ function updatePath() {
 }
 
 const controller = new AbortController();
+let resizeObserver: ResizeObserver | null = null;
 
 onMounted(() => {
   window.addEventListener("resize", updatePath, {
     signal: controller.signal,
   });
+
+  // Observe the container so the path is recalculated once its layout settles.
+  // On iOS Safari/Chrome the container's dimensions are often 0 on the first
+  // tick, so relying on the window "resize" event alone leaves the SVG sized
+  // at 0x0 and nothing renders.
+  if (typeof ResizeObserver !== "undefined" && props.containerRef) {
+    resizeObserver = new ResizeObserver(() => updatePath());
+    resizeObserver.observe(props.containerRef);
+  }
+
+  // Compute the initial path once the DOM has been laid out.
+  nextTick(updatePath);
 });
 
 onUnmounted(() => {
   controller.abort();
+  resizeObserver?.disconnect();
 });
 
 watch(
@@ -110,31 +126,29 @@ watch(
       :stroke-opacity="pathOpacity"
       stroke-linecap="round"
     />
-    <path :d="pathD" :stroke="`url(#${id}`" fill="none" stroke-linecap="round" />
+    <path :d="pathD" :stroke="`url(#${id})`" fill="none" stroke-linecap="round" />
     <defs>
-      <linearGradient
-        :id="id"
-        v-motion
-        :initial="{
-          opacity: 0,
-          x: props.reverse ? ['100%', '0%'] : ['0%', '100%'],
-        }"
-        :enter="{
-          opacity: 1,
-          x: props.reverse ? ['100%', '0%'] : ['0%', '100%'],
-          transition: {
-            duration: 1600,
-            type: 'keyframes',
-            easings: [0.16, 1, 0.3, 1],
-            repeat: Infinity,
-          },
-        }"
-        gradientUnits="userSpaceOnUse"
-        :x1="initial.x1"
-        :x2="initial.x2"
-        :y1="initial.y1"
-        :y2="initial.y2"
-      >
+      <linearGradient :id="id" gradientUnits="userSpaceOnUse" x1="0%" x2="0%" y1="0%" y2="0%">
+        <animate
+          attributeName="x1"
+          :values="gradientCoordinates.x1"
+          :dur="`${duration}s`"
+          :begin="`${delay}s`"
+          repeatCount="indefinite"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines="0.16 1 0.3 1"
+        />
+        <animate
+          attributeName="x2"
+          :values="gradientCoordinates.x2"
+          :dur="`${duration}s`"
+          :begin="`${delay}s`"
+          repeatCount="indefinite"
+          calcMode="spline"
+          keyTimes="0;1"
+          keySplines="0.16 1 0.3 1"
+        />
         <stop :stop-color="props.gradientStartColor" stop-opacity="0" />
         <stop :stop-color="props.gradientStartColor" />
         <stop offset="32.5%" :stop-color="props.gradientStopColor" />


### PR DESCRIPTION
## Describe the bug

Animated Beam was not showing on Chrome and Safari on iPhone (iOS 18.2, iPhone 15), and the beam was also static/invisible on desktop Safari.

## Root cause

Three issues, all surfacing on WebKit (Safari, and Chrome on iOS which is WebKit-backed):

1. **Gradient animated via a CSS transform.** The beam's motion came from applying a CSS `x` transform to the `<linearGradient>` element through `v-motion`. WebKit does not relocate an SVG gradient's paint via a CSS transform, so the beam never moved and read as invisible. Blink (desktop Chrome) tolerated it, which is why it worked there.

2. **Malformed gradient reference.** The gradient stroke used ``url(#${id}`` — missing the closing `)`. WebKit strictly rejects the unclosed `url(...)` reference so the gradient never resolved.

3. **SVG sized 0×0 on first paint.** `updatePath()` was only wired to the window `resize` event and the props watcher. On iOS the container reports 0×0 dimensions on the first tick and no `resize` fires afterward, leaving the SVG at width/height `0`.

## Fix

- Animate the gradient's own `x1`/`x2` attributes with native SVG (SMIL) `<animate>` elements — the standard, WebKit-supported approach — matching the direction and easeOutExpo easing of the upstream MagicUI implementation.
- Close the `url(#id)` gradient reference.
- Compute the initial path on mount via `nextTick` and observe the container with a `ResizeObserver` so the path recalculates once layout settles.

Applied to all copies of the component:
- the registry component (`components/spark-ui/animated-beam/animated-beam.vue`)
- the copyable source in the docs (`content/components/animated-beam.md`)
- the local copy used by the Multiple Outputs demo (`example/animated-beam/animated-beam.vue`)

Closes #83 

## Testing

- `pnpm typecheck` passes.
- All four demos (uni-directional, bi-directional, multiple inputs, multiple outputs) render the animated beam on Safari/iOS.